### PR TITLE
Replace all implicit dictionary creation to function calls

### DIFF
--- a/app/anime/router.py
+++ b/app/anime/router.py
@@ -33,7 +33,7 @@ from .schemas import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -60,10 +60,7 @@ async def search_anime(
             session, search, request_user, limit, offset
         )
 
-        return {
-            "pagination": pagination_dict(total, page, limit),
-            "list": anime.unique().all(),
-        }
+        return paginated_response(anime.unique().all(), total, page, limit)
 
     meilisearch_result = await meilisearch.search(
         constants.SEARCH_INDEX_ANIME,
@@ -115,10 +112,8 @@ async def anime_characters(
     limit, offset = pagination(page, size)
     total = await service.anime_characters_count(session, anime)
     characters = await service.anime_characters(session, anime, limit, offset)
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": characters.all(),
-    }
+
+    return paginated_response(characters.all(), total, page, limit)
 
 
 @router.get(
@@ -135,10 +130,8 @@ async def anime_staff(
     limit, offset = pagination(page, size)
     total = await service.anime_staff_count(session, anime)
     staff = await service.anime_staff(session, anime, limit, offset)
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": staff.unique().all(),
-    }
+
+    return paginated_response(staff.unique().all(), total, page, limit)
 
 
 @router.get(
@@ -155,10 +148,8 @@ async def anime_episodes(
     limit, offset = pagination(page, size)
     total = await service.anime_episodes_count(session, anime)
     episodes = await service.anime_episodes(session, anime, limit, offset)
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": episodes.all(),
-    }
+
+    return paginated_response(episodes.all(), total, page, limit)
 
 
 @router.get(
@@ -179,10 +170,7 @@ async def anime_recommendations(
         session, anime, request_user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": recommendations.unique().all(),
-    }
+    paginated_response(recommendations.unique().all(), total, page, limit)
 
 
 # TODO: remove me!
@@ -204,7 +192,4 @@ async def anime_franchise(
         session, anime, request_user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": franchise.unique().all(),
-    }
+    return paginated_response(franchise.unique().all(), total, page, limit)

--- a/app/anime/router.py
+++ b/app/anime/router.py
@@ -170,7 +170,9 @@ async def anime_recommendations(
         session, anime, request_user, limit, offset
     )
 
-    paginated_response(recommendations.unique().all(), total, page, limit)
+    return paginated_response(
+        recommendations.unique().all(), total, page, limit
+    )
 
 
 # TODO: remove me!

--- a/app/anime/service.py
+++ b/app/anime/service.py
@@ -1,7 +1,7 @@
+from sqlalchemy import select, desc, asc, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_loader_criteria
 from sqlalchemy.orm import with_expression
-from sqlalchemy import select, desc, asc
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import joinedload
 from .schemas import AnimeSearchArgs
@@ -35,7 +35,7 @@ async def get_anime_info_by_slug(
     return await session.scalar(
         select(Anime)
         .filter(
-            func.lower(Anime.slug) == slug.lower(),
+            func.lower(Anime.slug) == slug.lower(),  # type: ignore
             Anime.deleted == False,  # noqa: E712
         )
         .options(
@@ -53,7 +53,7 @@ async def get_anime_info_by_slug(
 
 async def anime_characters(
     session: AsyncSession, anime: Anime, limit: int, offset: int
-) -> list[AnimeCharacter]:
+) -> ScalarResult[AnimeCharacter]:
     return await session.scalars(
         select(AnimeCharacter)
         .filter(AnimeCharacter.anime == anime)
@@ -65,7 +65,7 @@ async def anime_characters(
 
 async def anime_staff(
     session: AsyncSession, anime: Anime, limit: int, offset: int
-) -> list[AnimeStaff]:
+) -> ScalarResult[AnimeStaff]:
     return await session.scalars(
         select(AnimeStaff)
         .join(Person, AnimeStaff.person)
@@ -86,7 +86,7 @@ async def anime_episodes_count(session: AsyncSession, anime: Anime) -> int:
 
 async def anime_episodes(
     session: AsyncSession, anime: Anime, limit: int, offset: int
-) -> list[AnimeStaff]:
+) -> ScalarResult[AnimeEpisode]:
     return await session.scalars(
         select(AnimeEpisode)
         .filter(AnimeEpisode.anime == anime)
@@ -146,7 +146,7 @@ async def anime_recommendations(
     request_user: User | None,
     limit: int,
     offset: int,
-) -> list[AnimeRecommendation]:
+) -> ScalarResult[Anime]:
     # Load request user watch statuses here
     load_options = [
         joinedload(Anime.watch),

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -1,5 +1,5 @@
 from app.models import User, UserOAuth, AuthToken, Client, AuthTokenRequest
-from app.utils import pagination, pagination_dict, utcnow
+from app.utils import pagination, utcnow, paginated_response
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends
 from app.schemas import UserResponse
@@ -262,10 +262,7 @@ async def third_party_auth_tokens(
         session, user, offset, limit, now
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": tokens.all(),
-    }
+    return paginated_response(tokens.all(), total, page, limit)
 
 
 @router.delete(

--- a/app/collections/router.py
+++ b/app/collections/router.py
@@ -22,7 +22,7 @@ from .dependencies import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -52,10 +52,7 @@ async def get_collections(
         session, request_user, args, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": collections.unique().all(),
-    }
+    return paginated_response(collections.unique().all(), total, page, limit)
 
 
 @router.post("/create", response_model=CollectionResponse)

--- a/app/collections/service.py
+++ b/app/collections/service.py
@@ -1,13 +1,3 @@
-from sqlalchemy import (
-    select,
-    desc,
-    asc,
-    delete,
-    update,
-    and_,
-    func,
-    ScalarResult,
-)
 from app.service import content_type_to_content_class
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Select
@@ -15,17 +5,24 @@ from app.utils import utcnow
 from app import constants
 from uuid import UUID
 
-from .schemas import (
-    CollectionsListArgs,
-    CollectionArgs,
-)
-
 from app.service import (
     collection_comments_load_options,
     collections_load_options,
     get_user_by_username,
     create_log,
 )
+
+from sqlalchemy import (
+    ScalarResult,
+    select,
+    delete,
+    update,
+    func,
+    desc,
+    and_,
+    asc,
+)
+
 
 from app.models import (
     CharacterCollectionContent,
@@ -37,6 +34,11 @@ from app.models import (
     CollectionComment,
     Collection,
     User,
+)
+
+from .schemas import (
+    CollectionsListArgs,
+    CollectionArgs,
 )
 
 

--- a/app/collections/service.py
+++ b/app/collections/service.py
@@ -1,4 +1,13 @@
-from sqlalchemy import select, desc, asc, delete, update, and_, func
+from sqlalchemy import (
+    select,
+    desc,
+    asc,
+    delete,
+    update,
+    and_,
+    func,
+    ScalarResult,
+)
 from app.service import content_type_to_content_class
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.selectable import Select
@@ -163,7 +172,7 @@ async def get_collections(
     args: CollectionsListArgs,
     limit: int,
     offset: int,
-) -> list[Collection]:
+) -> ScalarResult[Collection]:
     query = await collections_list_filter(
         collections_load_options(
             select(Collection),

--- a/app/comments/service.py
+++ b/app/comments/service.py
@@ -1,5 +1,5 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, desc, asc, func
+from sqlalchemy import select, desc, asc, func, ScalarResult
 from sqlalchemy.orm import with_expression
 from sqlalchemy.orm import immediateload
 from app.utils import round_datettime
@@ -43,7 +43,7 @@ from app.models import (
 )
 
 
-content_type_to_comment_class = {
+content_type_to_comment_class: dict[str, type[Comment]] = {
     constants.CONTENT_COLLECTION: CollectionComment,
     constants.CONTENT_SYSTEM_EDIT: EditComment,
     constants.CONTENT_ANIME: AnimeComment,
@@ -164,7 +164,7 @@ async def get_comments_by_content_id(
     request_user: User | None,
     limit: int,
     offset: int,
-) -> list[Edit]:
+) -> ScalarResult[Comment]:
     """Return comemnts for given content"""
 
     return await session.scalars(

--- a/app/companies/router.py
+++ b/app/companies/router.py
@@ -24,7 +24,7 @@ from .schemas import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -51,10 +51,7 @@ async def search_companies(
             session, search.type, limit, offset
         )
 
-        return {
-            "pagination": pagination_dict(total, page, limit),
-            "list": companies.all(),
-        }
+        return paginated_response(companies.all(), total, page, limit)
 
     search_filter = []
 
@@ -88,7 +85,4 @@ async def company_anime(
         session, company, args.type, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": anime.all(),
-    }
+    return paginated_response(anime.all(), total, page, limit)

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -73,7 +73,9 @@ async def _auth_token_or_abort(
     if not token:
         return Abort("auth", "missing-token")
 
-    if not (token := await get_auth_token(session, token)):
+    token = await get_auth_token(session, token)
+
+    if not token:
         return Abort("auth", "invalid-token")
 
     if not token.user:
@@ -90,6 +92,7 @@ async def _auth_token_or_abort(
 
     return token
 
+
 async def auth_token_required(
     token: AuthToken | Abort = Depends(_auth_token_or_abort),
 ) -> AuthToken:
@@ -100,7 +103,7 @@ async def auth_token_required(
 
 
 async def auth_token_optional(
-    token: AuthToken | Abort = Depends(_auth_token_or_abort)
+    token: AuthToken | Abort = Depends(_auth_token_or_abort),
 ) -> AuthToken | None:
     if isinstance(token, Abort):
         return None

--- a/app/edit/router.py
+++ b/app/edit/router.py
@@ -24,7 +24,7 @@ from app.dependencies import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -67,10 +67,7 @@ async def get_edits(
     total = await service.count_edits(session, args)
     edits = await service.get_edits(session, args, limit, offset)
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": edits.all(),
-    }
+    return paginated_response(edits.all(), total, page, limit)
 
 
 @router.get("/{edit_id}", response_model=EditResponse)
@@ -167,7 +164,4 @@ async def get_content_edit_todo(
         session, content_type, todo_type, request_user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": content.unique().all(),
-    }
+    return paginated_response(content.unique().all(), total, page, limit)

--- a/app/edit/service.py
+++ b/app/edit/service.py
@@ -1,13 +1,12 @@
+from sqlalchemy import select, asc, desc, func, ScalarResult
 from app.models.list.read import MangaRead, NovelRead
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_loader_criteria
-from sqlalchemy import select, asc, desc, func
 from sqlalchemy.sql.selectable import Select
 from sqlalchemy.orm import with_expression
 from app.utils import round_datettime
 from sqlalchemy.orm import joinedload
 from .utils import calculate_before
-from app.errors import Abort
 from app.utils import utcnow
 from app.models import Log
 from app import constants
@@ -167,7 +166,7 @@ async def get_edits(
     args: EditSearchArgs,
     limit: int,
     offset: int,
-) -> list[Edit]:
+) -> ScalarResult[Edit]:
     """Return all edits"""
 
     query = await edits_search_filter(session, args, select(Edit))
@@ -448,7 +447,7 @@ async def content_todo_total(
 
 async def content_todo(
     session: AsyncSession,
-    content_type: EditContentTypeEnum,
+    content_type: EditContentToDoEnum,
     todo_type: ContentToDoEnum,
     request_user: User | None,
     limit: int,

--- a/app/favourite/router.py
+++ b/app/favourite/router.py
@@ -1,4 +1,4 @@
-from app.utils import pagination, pagination_dict
+from app.utils import pagination, paginated_response
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends
 from app.database import get_session
@@ -109,7 +109,4 @@ async def favourite_list(
         session, content_type, user, request_user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": content.unique().all(),
-    }
+    return paginated_response(content.unique().all(), total, page, limit)

--- a/app/favourite/service.py
+++ b/app/favourite/service.py
@@ -1,8 +1,8 @@
+from sqlalchemy import select, desc, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_loader_criteria
 from .schemas import FavouriteContentTypeEnum
 from sqlalchemy.orm import with_expression
-from sqlalchemy import select, desc, func
 from sqlalchemy.orm import joinedload
 from app.utils import utcnow
 from app import constants
@@ -105,7 +105,7 @@ async def get_user_favourite_list(
     request_user: User | None,
     limit: int,
     offset: int,
-) -> list[Favourite]:
+) -> ScalarResult[Favourite]:
     # At some point I decided that best approach for favourite would be
     # to return list of content with some extra metadata (created/order)
     # instead of returning list of favourite entries with content loaded.

--- a/app/follow/router.py
+++ b/app/follow/router.py
@@ -1,4 +1,4 @@
-from app.utils import pagination_dict, pagination
+from app.utils import pagination, paginated_response
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends
 from app.database import get_session
@@ -106,10 +106,7 @@ async def following_list(
         session, request_user, user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": following.all(),
-    }
+    return paginated_response(following.all(), total, page, limit)
 
 
 @router.get(
@@ -132,7 +129,4 @@ async def followers_list(
         session, request_user, user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": followers.all(),
-    }
+    return paginated_response(followers.all(), total, page, limit)

--- a/app/history/router.py
+++ b/app/history/router.py
@@ -11,7 +11,7 @@ from .schemas import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -48,10 +48,8 @@ async def following_history(
     history = await service.get_following_history(
         session, user_ids, limit, offset
     )
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": history.all(),
-    }
+
+    return paginated_response(history.all(), total, page, limit)
 
 
 @router.get(
@@ -68,7 +66,5 @@ async def user_history(
     limit, offset = pagination(page, size)
     total = await service.get_user_history_count(session, user)
     history = await service.get_user_history(session, user, limit, offset)
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": history.all(),
-    }
+
+    return paginated_response(history.all(), total, page, limit)

--- a/app/history/service.py
+++ b/app/history/service.py
@@ -1,5 +1,5 @@
+from sqlalchemy import select, desc, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, desc, func
 from sqlalchemy.orm import joinedload
 
 from app.models import (
@@ -17,7 +17,7 @@ async def get_user_history_count(session: AsyncSession, user: User) -> int:
 
 async def get_user_history(
     session: AsyncSession, user: User, limit: int, offset: int
-) -> User:
+) -> ScalarResult[History]:
     """Get user history"""
 
     return await session.scalars(
@@ -51,7 +51,7 @@ async def get_following_history_count(
 
 async def get_following_history(
     session: AsyncSession, user_ids: list, limit: int, offset: int
-) -> User:
+) -> ScalarResult[History]:
     """Get following history"""
 
     return await session.scalars(

--- a/app/manga/service.py
+++ b/app/manga/service.py
@@ -1,10 +1,10 @@
+from sqlalchemy import select, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_loader_criteria
 from sqlalchemy.orm import with_expression
 from .utils import build_manga_filters_ms
 from app.schemas import MangaSearchArgs
 from sqlalchemy.orm import joinedload
-from sqlalchemy import select, func
 from app import meilisearch
 from app import constants
 
@@ -102,7 +102,7 @@ async def manga_characters_count(session: AsyncSession, manga: Manga) -> int:
 
 async def manga_characters(
     session: AsyncSession, manga: Manga, limit: int, offset: int
-) -> list[MangaCharacter]:
+) -> ScalarResult[MangaCharacter]:
     return await session.scalars(
         select(MangaCharacter)
         .filter(MangaCharacter.manga == manga)

--- a/app/meilisearch.py
+++ b/app/meilisearch.py
@@ -1,6 +1,6 @@
 from meilisearch_python_sdk.errors import MeilisearchError
 from meilisearch_python_sdk import AsyncClient
-from app.utils import pagination_dict
+from app.utils import paginated_response
 from app.utils import get_settings
 from app.errors import Abort
 from app import constants
@@ -28,12 +28,12 @@ async def search(
                 page=page,
             )
 
-            return {
-                "pagination": pagination_dict(
-                    result.total_hits, result.page, result.hits_per_page
-                ),
-                "list": result.hits,
-            }
+            return paginated_response(
+                result.hits,
+                result.total_hits,
+                result.page,
+                result.hits_per_page,
+            )
 
     except MeilisearchError:
         raise Abort("search", "query-down")

--- a/app/notifications/router.py
+++ b/app/notifications/router.py
@@ -13,7 +13,7 @@ from .schemas import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -46,10 +46,7 @@ async def notifications(
         session, user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": notifications.all(),
-    }
+    return paginated_response(notifications.all(), total, page, limit)
 
 
 @router.get(

--- a/app/notifications/service.py
+++ b/app/notifications/service.py
@@ -1,4 +1,4 @@
-from sqlalchemy import select, desc, update, func
+from sqlalchemy import select, desc, update, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.utils import utcnow
 from uuid import UUID
@@ -33,7 +33,7 @@ async def get_user_notifications_count(
 
 async def get_user_notifications(
     session: AsyncSession, user: User, limit: int, offset: int
-) -> User:
+) -> ScalarResult[Notification]:
     """Get user notifications"""
 
     return await session.scalars(

--- a/app/novel/router.py
+++ b/app/novel/router.py
@@ -28,7 +28,7 @@ from app.schemas import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -50,25 +50,22 @@ async def search_novel(
     page: int = Depends(get_page),
     size: int = Depends(get_size),
 ):
-    if not search.query:
-        limit, offset = pagination(page, size)
-        total = await service.novel_search_total(session, search)
-        novel = await service.novel_search(
-            session, search, request_user, limit, offset
+    if search.query:
+        return await service.novel_search_query(
+            session,
+            search,
+            request_user,
+            page,
+            size,
         )
 
-        return {
-            "pagination": pagination_dict(total, page, limit),
-            "list": novel.unique().all(),
-        }
-
-    return await service.novel_search_query(
-        session,
-        search,
-        request_user,
-        page,
-        size,
+    limit, offset = pagination(page, size)
+    total = await service.novel_search_total(session, search)
+    novel = await service.novel_search(
+        session, search, request_user, limit, offset
     )
+
+    return paginated_response(novel.unique().all(), total, page, limit)
 
 
 @router.get(
@@ -95,7 +92,4 @@ async def novel_characters(
     total = await service.novel_characters_count(session, novel)
     characters = await service.novel_characters(session, novel, limit, offset)
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": characters.all(),
-    }
+    return paginated_response(characters.all(), total, page, limit)

--- a/app/novel/service.py
+++ b/app/novel/service.py
@@ -1,10 +1,10 @@
+from sqlalchemy import select, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_loader_criteria
 from sqlalchemy.orm import with_expression
 from .utils import build_novel_filters_ms
 from app.schemas import NovelSearchArgs
 from sqlalchemy.orm import joinedload
-from sqlalchemy import select, func
 from app import meilisearch
 from app import constants
 
@@ -102,7 +102,7 @@ async def novel_characters_count(session: AsyncSession, novel: Novel) -> int:
 
 async def novel_characters(
     session: AsyncSession, novel: Novel, limit: int, offset: int
-) -> list[NovelCharacter]:
+) -> ScalarResult[NovelCharacter]:
     return await session.scalars(
         select(NovelCharacter)
         .filter(NovelCharacter.novel == novel)

--- a/app/read/router.py
+++ b/app/read/router.py
@@ -15,7 +15,7 @@ from app.dependencies import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -100,10 +100,7 @@ async def get_read_following(
         session, user, content_type, content, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": read.unique().all(),
-    }
+    return paginated_response(read.unique().all(), total, page, limit)
 
 
 @router.get(
@@ -162,7 +159,4 @@ async def user_read_list(
         session, search, content_type, user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": read.all(),
-    }
+    return paginated_response(read.all(), total, page, limit)

--- a/app/read/service.py
+++ b/app/read/service.py
@@ -1,8 +1,8 @@
+from sqlalchemy import select, desc, func, ScalarResult
 from app.service import content_type_to_content_class
 from sqlalchemy.ext.asyncio import AsyncSession
 from .schemas import ReadArgs, ReadSearchArgs
 from sqlalchemy.orm import contains_eager
-from sqlalchemy import select, desc, func
 from sqlalchemy.orm import joinedload
 from app.utils import utcnow
 from app import constants
@@ -293,7 +293,7 @@ async def get_user_read_list(
     user: User,
     limit: int,
     offset: int,
-) -> list[Read]:
+) -> ScalarResult[Read]:
     query = select(Read).filter(
         Read.content_type == content_type,
         Read.deleted == False,  # noqa: E712

--- a/app/schedule/router.py
+++ b/app/schedule/router.py
@@ -15,7 +15,7 @@ from app.dependencies import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -39,7 +39,4 @@ async def anime_schedule(
         session, args, request_user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": schedule.unique().all(),
-    }
+    return paginated_response(schedule.unique().all(), total, page, limit)

--- a/app/stats/router.py
+++ b/app/stats/router.py
@@ -10,7 +10,7 @@ from app.dependencies import (
 )
 
 from app.utils import (
-    pagination_dict,
+    paginated_response,
     pagination,
 )
 
@@ -28,7 +28,4 @@ async def edits_top(
     total = await service.get_edits_top_count(session)
     top = await service.get_edits_top(session, limit, offset)
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": top.all(),
-    }
+    return paginated_response(top.all(), total, page, limit)

--- a/app/system/router.py
+++ b/app/system/router.py
@@ -1,18 +1,13 @@
+from app.utils import get_settings, paginated_response, pagination
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_page, get_size
 from .dependencies import validate_backup_token
 from fastapi import APIRouter, Request, Depends
 from .schemas import ImagesPaginationResponse
 from app.database import get_session
-from app.utils import get_settings
 from .schemas import EventArgs
 from . import service
 import aiohttp
-
-from app.utils import (
-    pagination_dict,
-    pagination,
-)
 
 
 router = APIRouter(include_in_schema=False)
@@ -67,7 +62,4 @@ async def backup_images(
     total = await service.get_images_count(session)
     images = await service.get_images(session, limit, offset)
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": images.all(),
-    }
+    return paginated_response(images.all(), total, page, limit)

--- a/app/utils.py
+++ b/app/utils.py
@@ -274,7 +274,9 @@ def pagination_dict(total, page, limit):
 
 
 def paginated_response(
-    items: Sequence[typing.Union[DeclarativeBase, "CustomModel"]],
+    items: Sequence[
+        typing.Union[DeclarativeBase, "CustomModel", dict[str, typing.Any]]
+    ],
     total: int,
     page: int,
     limit: int,

--- a/app/watch/router.py
+++ b/app/watch/router.py
@@ -18,6 +18,7 @@ from app.dependencies import (
 from app.utils import (
     pagination_dict,
     pagination,
+    paginated_response,
 )
 
 from .schemas import (
@@ -90,10 +91,7 @@ async def get_watch_following(
         session, user, anime, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": watch.unique().all(),
-    }
+    return paginated_response(watch.unique().all(), total, page, limit)
 
 
 @router.get(
@@ -128,7 +126,4 @@ async def user_watch_list(
         session, search, user, limit, offset
     )
 
-    return {
-        "pagination": pagination_dict(total, page, limit),
-        "list": anime.all(),
-    }
+    return paginated_response(anime.all(), total, page, limit)

--- a/app/watch/service.py
+++ b/app/watch/service.py
@@ -1,5 +1,5 @@
+from sqlalchemy import select, desc, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, desc, func
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
 from app.utils import utcnow
@@ -186,7 +186,7 @@ async def get_user_watch_list(
     user: User,
     limit: int,
     offset: int,
-) -> list[AnimeWatch]:
+) -> ScalarResult[AnimeWatch]:
     query = select(AnimeWatch).filter(
         AnimeWatch.deleted == False,  # noqa: E712
         AnimeWatch.user == user,


### PR DESCRIPTION
This PR replaces implicit dictionary creation in endpoints with paginated responses to functions calls.

```
{"pagination": pagination_dict(...), "list": ...} -> paginated_response(...)
```

And additionally, fixes some type-hints in **/service.py files