### PR TITLE
Allow arbitrary url for application client endpoint.

### DIFF
--- a/app/client/schemas.py
+++ b/app/client/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import Field, HttpUrl, field_validator
+from pydantic import AnyUrl, Field, field_validator
 
 from app.schemas import CustomModel, ClientResponse, PaginationResponse
 from app import constants, utils
@@ -27,8 +27,8 @@ class ClientCreate(CustomModel):
         min_length=3,
         max_length=constants.MAX_CLIENT_DESCRIPTION_LENGTH,
     )
-    endpoint: HttpUrl = Field(
-        examples=["https://example.com", "http://localhost/auth/confirm"],
+    endpoint: AnyUrl = Field(
+        examples=["https://example.com", "http://localhost/auth/confirm", "hikka://auth"],
         description="Endpoint of the client. "
         "User will be redirected to that endpoint after successful "
         "authorization",
@@ -43,7 +43,7 @@ class ClientCreate(CustomModel):
         return utils.remove_bad_characters(v).strip()
 
     @field_validator("endpoint")
-    def validate_endpoint(cls, v: HttpUrl) -> HttpUrl:
+    def validate_endpoint(cls, v: AnyUrl) -> AnyUrl:
         if len(str(v)) > constants.MAX_CLIENT_ENDPOINT_LENGTH:
             raise ValueError(
                 f"Endpoint length should be less than {constants.MAX_CLIENT_ENDPOINT_LENGTH}"
@@ -65,7 +65,7 @@ class ClientUpdate(CustomModel):
         max_length=constants.MAX_CLIENT_DESCRIPTION_LENGTH,
         min_length=3,
     )
-    endpoint: HttpUrl | None = Field(
+    endpoint: AnyUrl | None = Field(
         None,
         description="Endpoint of the client",
         max_length=constants.MAX_CLIENT_ENDPOINT_LENGTH,
@@ -83,7 +83,7 @@ class ClientUpdate(CustomModel):
         return utils.remove_bad_characters(v).strip()
 
     @field_validator("endpoint")
-    def validate_endpoint(cls, v: HttpUrl | None) -> HttpUrl | None:
+    def validate_endpoint(cls, v: AnyUrl | None) -> AnyUrl | None:
         if len(str(v)) > constants.MAX_CLIENT_ENDPOINT_LENGTH:
             raise ValueError(
                 f"Endpoint length should be less than {constants.MAX_CLIENT_ENDPOINT_LENGTH}"

--- a/tests/auth/test_auth_thirdparty.py
+++ b/tests/auth/test_auth_thirdparty.py
@@ -13,7 +13,7 @@ from tests.client_requests import (
 async def test_auth_thirdparty(client, test_token):
     name = "thirdparty-client"
     description = "Third-party client"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
 
     response = await request_client_create(
         client, test_token, name, description, endpoint

--- a/tests/client/test_client_create.py
+++ b/tests/client/test_client_create.py
@@ -7,7 +7,7 @@ from app import constants
 async def test_client_create(client, test_token, test_user):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
     response = await request_client_create(
         client,
         test_token,
@@ -41,7 +41,7 @@ async def test_client_create_invalid_endpoint(client, test_token):
 async def test_client_create_double(client, test_token):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
     response = await request_client_create(
         client, test_token, name, description, endpoint
     )
@@ -63,7 +63,7 @@ async def test_too_long_fields(client, test_token):
         test_token,
         "a" * (constants.MAX_CLIENT_NAME_LENGTH + 1),
         "description",
-        "http://localhost/",
+        "hikka://auth/",
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -77,7 +77,7 @@ async def test_too_long_fields(client, test_token):
         test_token,
         "name",
         "a" * (constants.MAX_CLIENT_DESCRIPTION_LENGTH + 1),
-        "http://localhost/",
+        "hikka://auth/",
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -91,7 +91,7 @@ async def test_too_long_fields(client, test_token):
         test_token,
         "name",
         "description",
-        "http://localhost/" + "a" * (constants.MAX_CLIENT_ENDPOINT_LENGTH + 1),
+        "hikka://auth/" + "a" * (constants.MAX_CLIENT_ENDPOINT_LENGTH + 1),
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -110,7 +110,7 @@ async def test_too_short_fields(client, test_token):
         test_token,
         "a",
         "description",
-        "http://localhost/",
+        "hikka://auth/",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -124,7 +124,7 @@ async def test_too_short_fields(client, test_token):
         test_token,
         "name",
         "a",
-        "http://localhost/",
+        "hikka://auth/",
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 

--- a/tests/client/test_client_delete.py
+++ b/tests/client/test_client_delete.py
@@ -12,7 +12,7 @@ from tests.client_requests import (
 async def test_client_delete(client, test_token):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
 
     response = await request_client_create(
         client, test_token, name, description, endpoint

--- a/tests/client/test_client_info.py
+++ b/tests/client/test_client_info.py
@@ -19,7 +19,7 @@ async def test_client_full_info_nonexistent(client, test_token):
 async def test_client_full_info(client, test_token, test_user):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
 
     response = await request_client_create(
         client, test_token, name, description, endpoint
@@ -43,7 +43,7 @@ async def test_client_full_info(client, test_token, test_user):
 async def test_client_info_by_reference(client, test_token, test_user):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
     response = await request_client_create(
         client, test_token, name, description, endpoint
     )

--- a/tests/client/test_client_list.py
+++ b/tests/client/test_client_list.py
@@ -6,7 +6,7 @@ from tests.client_requests import request_list_clients, request_client_create
 async def test_client_create(client, test_token, test_user):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
     response = await request_client_create(
         client,
         test_token,

--- a/tests/client/test_client_update.py
+++ b/tests/client/test_client_update.py
@@ -9,7 +9,7 @@ from app import constants
 async def test_client_update(client, test_token):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
 
     response = await request_client_create(
         client, test_token, name, description, endpoint
@@ -61,7 +61,7 @@ async def test_too_long_fields(client, test_token):
 
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
 
     response = await request_client_create(
         client, test_token, name, description, endpoint
@@ -100,7 +100,7 @@ async def test_too_long_fields(client, test_token):
         client,
         test_token,
         client_reference,
-        endpoint="http://localhost/"
+        endpoint="hikka://auth/"
         + "a" * (constants.MAX_CLIENT_ENDPOINT_LENGTH + 1),
     )
 
@@ -117,7 +117,7 @@ async def test_too_short_fields(client, test_token):
 
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
 
     response = await request_client_create(
         client, test_token, name, description, endpoint

--- a/tests/client/test_client_verify.py
+++ b/tests/client/test_client_verify.py
@@ -5,7 +5,7 @@ from starlette import status
 async def test_client_verify(client, test_token, test_user, moderator_token):
     name = "test-client"
     description = "test client description"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
     response = await request_client_create(
         client,
         test_token,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -92,7 +92,7 @@ async def create_client(
     secret: str,
     name: str = "TestClient",
     description: str = "Test client",
-    endpoint: str = "http://localhost/",
+    endpoint: str = "hikka://auth/",
     verified: bool = False,
 ):
     now = utcnow()

--- a/tests/sync/notifications/test_notification_thirdparty_login.py
+++ b/tests/sync/notifications/test_notification_thirdparty_login.py
@@ -15,7 +15,7 @@ from tests.client_requests import (
 async def test_notification_thirdparty_login(client, test_token, test_session):
     name = "thirdparty-client"
     description = "Third-party client"
-    endpoint = "http://localhost/"
+    endpoint = "hikka://auth/"
     scope = [constants.SCOPE_READ_USER_DETAILS]
 
     response = await request_client_create(


### PR DESCRIPTION
This helps for mobile apps by directly opening instead of having the app intercept the calls and what not. You can read more here (that I found from a quick google search) https://alirezahamid.medium.com/4d9fa3e6cdbe