### PR TITLE
Set pre-generated password hash in tests.helpers:create_user

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,7 +26,7 @@ async def create_user(
     user = User(
         **{
             "activation_expire": utcnow() + timedelta(hours=3),
-            "password_hash": hashpwd("password"),
+            "password_hash": "$2b$12$PHjOVmEP7LwdR76lRrRlnOlBd1/jUYeALVbsbLXYU6cyWPUoSeasq",
             "activation_token": new_token(),
             "email_confirmed": activated,
             "username": username,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
 from app.models import User, UserOAuth, AuthToken, Client
-from app.utils import new_token, hashpwd, utcnow
 from sqlalchemy.ext.asyncio import AsyncSession
+from app.utils import new_token, utcnow
 from datetime import timedelta
 from sqlalchemy import select
 from app import constants


### PR DESCRIPTION
This PR reduces amount of time spent on tests setup by using pre-generated hash for string "password" in user creation helper function