### PR TITLE
Update only latest records in watch/read history

### DIFF
--- a/app/sync/history/__init__.py
+++ b/app/sync/history/__init__.py
@@ -66,13 +66,13 @@ async def generate_history(session: AsyncSession):
             constants.LOG_WATCH_UPDATE,
             constants.LOG_WATCH_CREATE,
         ]:
-            await generate_watch(session, log, watch_delta)
+            await generate_watch(session, log)
 
         if log.log_type in [
             constants.LOG_READ_UPDATE,
             constants.LOG_READ_CREATE,
         ]:
-            await generate_read(session, log, read_delta)
+            await generate_read(session, log)
 
         if log.log_type == constants.LOG_WATCH_DELETE:
             await generate_watch_delete(session, log, watch_delta)

--- a/app/sync/history/service.py
+++ b/app/sync/history/service.py
@@ -25,3 +25,15 @@ async def get_history(
             desc(History.created),
         )
     )
+
+
+async def get_latest_history(
+    session: AsyncSession,
+    user_id: UUID,
+):
+    return await session.scalar(
+        select(History)
+        .filter(History.user_id == user_id)
+        .order_by(desc(History.updated))
+        .limit(1)
+    )


### PR DESCRIPTION
This PR removes 'threshold' for history records to update. Instead service will update only latest record if it exists and belongs to content of the log record being used to create history records.

Expected service behavior after this update:
- User adds manga to read list -> user adds another manga to read list -> user completes read of the first manga
  In this case will be generated 3 records of history:
    1. First manga was added to the read list
    2. Seconds manga was added to the read list
    3. First manga was completed

- User adds anime to watch list -> user adds another anime to watch list -> user completes watch of the first anime
  In this case will be generate 3 records of history:
    1. First anime was added to the watch list
    2. Seconds anime was added to the watch list
    3. First anime was completed
   