### PR TITLE
Update only latest records in read/watch history

### DIFF
--- a/app/sync/history/__init__.py
+++ b/app/sync/history/__init__.py
@@ -66,13 +66,13 @@ async def generate_history(session: AsyncSession):
             constants.LOG_WATCH_UPDATE,
             constants.LOG_WATCH_CREATE,
         ]:
-            await generate_watch(session, log)
+            await generate_watch(session, log, watch_delta)
 
         if log.log_type in [
             constants.LOG_READ_UPDATE,
             constants.LOG_READ_CREATE,
         ]:
-            await generate_read(session, log)
+            await generate_read(session, log, read_delta)
 
         if log.log_type == constants.LOG_WATCH_DELETE:
             await generate_watch_delete(session, log, watch_delta)

--- a/app/sync/history/__init__.py
+++ b/app/sync/history/__init__.py
@@ -66,13 +66,13 @@ async def generate_history(session: AsyncSession):
             constants.LOG_WATCH_UPDATE,
             constants.LOG_WATCH_CREATE,
         ]:
-            await generate_watch(session, log, watch_delta)
+            await generate_watch(session, log)
 
         if log.log_type in [
             constants.LOG_READ_UPDATE,
             constants.LOG_READ_CREATE,
         ]:
-            await generate_read(session, log, read_delta)
+            await generate_read(session, log)
 
         if log.log_type == constants.LOG_WATCH_DELETE:
             await generate_watch_delete(session, log, watch_delta)

--- a/app/sync/history/generate/read.py
+++ b/app/sync/history/generate/read.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import History, Log
 from app import constants
@@ -5,10 +7,9 @@ from .. import service
 import copy
 
 
-async def generate_read(
-    session: AsyncSession,
-    log: Log,
-):
+async def generate_read(session: AsyncSession, log: Log, delta: timedelta):
+    threshold = log.created - delta
+
     history_type = (
         constants.HISTORY_READ_MANGA
         if log.data["content_type"] == constants.CONTENT_MANGA
@@ -22,6 +23,7 @@ async def generate_read(
     if latest_history is not None and (
         latest_history.target_id != log.target_id
         or latest_history.history_type != history_type
+        or latest_history.updated < threshold
     ):
         history = None
 

--- a/app/sync/history/generate/watch.py
+++ b/app/sync/history/generate/watch.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models import History, Log
 from app import constants
@@ -5,10 +7,9 @@ from .. import service
 import copy
 
 
-async def generate_watch(
-    session: AsyncSession,
-    log: Log,
-):
+async def generate_watch(session: AsyncSession, log: Log, delta: timedelta):
+    threshold = log.created - delta
+
     history_type = constants.HISTORY_WATCH
 
     latest_history = await service.get_latest_history(session, log.user_id)
@@ -18,6 +19,7 @@ async def generate_watch(
     if latest_history is not None and (
         latest_history.target_id != log.target_id
         or latest_history.history_type != history_type
+        or latest_history.created < threshold
     ):
         history = None
 

--- a/app/sync/history/service.py
+++ b/app/sync/history/service.py
@@ -25,3 +25,15 @@ async def get_history(
             desc(History.created),
         )
     )
+
+
+async def get_latest_history(
+    session: AsyncSession,
+    user_id: UUID,
+):
+    return await session.scalar(
+        select(History)
+        .filter(History.user_id == user_id)
+        .order_by(desc(History.updated))
+        .limit(1)
+    )

--- a/tests/sync/history/test_history_read.py
+++ b/tests/sync/history/test_history_read.py
@@ -2,6 +2,7 @@ from app.sync.history import generate_history
 from sqlalchemy import select, desc, func
 from app.models import Log, History
 from datetime import datetime
+from typing import Iterator
 from app import constants
 from uuid import uuid4
 
@@ -81,8 +82,7 @@ async def test_history_read(test_session, create_test_user):
         },
         {
             # Finally manga is finished and status changed
-            # Everything under 6 hours (wow)
-            "created": datetime(2024, 2, 1, 5, 50, 0),
+            "created": datetime(2024, 2, 2, 5, 50, 0),
             "log_type": constants.LOG_READ_UPDATE,
             "target_id": fake_manga_id,
             "user_id": user_id,
@@ -115,30 +115,42 @@ async def test_history_read(test_session, create_test_user):
 
     # Count history
     history_count = await test_session.scalar(select(func.count(History.id)))
-    assert history_count == 3
+    assert history_count == 4
 
     # And how get history entry
-    history = await test_session.scalars(
+    result = await test_session.scalars(
         select(History).order_by(desc(History.created))
     )
-    history = history.all()
 
-    assert len(history[0].used_logs) == 4
-    assert history[0].data == {
+    history: Iterator[History] = iter(result.all())
+
+    record = next(history)
+    assert len(record.used_logs) == 1
+    assert record.data == {
+        "before": {"volumes": 9, "score": 5, "status": "reading"},
         "after": {"volumes": 12, "score": 7, "status": "completed"},
-        "before": {"volumes": 0, "score": 0, "status": "planned"},
         "new_read": False,
     }
 
-    assert len(history[1].used_logs) == 1
-    assert history[1].data == {
+    record = next(history)
+    assert len(record.used_logs) == 3
+    assert record.data == {
+        "before": {"volumes": 0, "score": 0, "status": "planned"},
+        "after": {"volumes": 9, "score": 5, "status": "reading"},
+        "new_read": False,
+    }
+
+    record = next(history)
+    assert len(record.used_logs) == 1
+    assert record.data == {
         "after": {"status": "planned"},
         "before": {"status": None},
         "new_read": True,
     }
 
-    assert len(history[2].used_logs) == 1
-    assert history[2].data == {
+    record = next(history)
+    assert len(record.used_logs) == 1
+    assert record.data == {
         "after": {"status": "planned"},
         "before": {"status": None},
         "new_read": True,

--- a/tests/sync/history/test_history_watch.py
+++ b/tests/sync/history/test_history_watch.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 from app.sync.history import generate_history
 from sqlalchemy import select, desc, func
 from app.models import Log, History
@@ -76,8 +78,7 @@ async def test_history_watch(test_session, create_test_user):
         },
         {
             # Finally anime is finished and status changed
-            # Everything under 6 hours (wow)
-            "created": datetime(2024, 2, 1, 5, 50, 0),
+            "created": datetime(2024, 2, 2, 5, 50, 0),
             "log_type": constants.LOG_WATCH_UPDATE,
             "target_id": fake_anime_id,
             "user_id": user_id,
@@ -109,30 +110,41 @@ async def test_history_watch(test_session, create_test_user):
 
     # Count history
     history_count = await test_session.scalar(select(func.count(History.id)))
-    assert history_count == 3
+    assert history_count == 4
 
     # And how get history entry
-    history = await test_session.scalars(
+    result = await test_session.scalars(
         select(History).order_by(desc(History.created))
     )
-    history = history.all()
+    history: Iterator[History] = iter(result.all())
 
-    assert len(history[0].used_logs) == 4
-    assert history[0].data == {
+    record = next(history)
+    assert len(record.used_logs) == 1
+    assert record.data == {
+        "before": {"episodes": 9, "score": 5, "status": "watching"},
         "after": {"episodes": 12, "score": 7, "status": "completed"},
+        "new_watch": False,
+    }
+
+    record = next(history)
+    assert len(record.used_logs) == 3
+    assert record.data == {
+        "after": {"episodes": 9, "score": 5, "status": "watching"},
         "before": {"episodes": 0, "score": 0, "status": "planned"},
         "new_watch": False,
     }
 
-    assert len(history[1].used_logs) == 1
-    assert history[1].data == {
+    record = next(history)
+    assert len(record.used_logs) == 1
+    assert record.data == {
         "after": {"status": "planned"},
         "before": {"status": None},
         "new_watch": True,
     }
 
-    assert len(history[2].used_logs) == 1
-    assert history[2].data == {
+    record = next(history)
+    assert len(record.used_logs) == 1
+    assert record.data == {
         "after": {"status": "planned"},
         "before": {"status": None},
         "new_watch": True,


### PR DESCRIPTION
This PR makes service to update only latest history records, taking into account ``watch_delay`` and ``read_delay``. This ensures that service will not update history record that belongs to log record content, but on top of that record is another record that does not belongs to such content.