### PR TITLE
Remove lower() function calls from slug related queries to utilize the indexes correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ Optionally you also need to install Meilisearch [1.4.2](https://github.com/meili
    poetry install
    ```
 3. Create `alembic.ini` and `settings.toml` files in project root directory, example configs can be found in [docs/](docs/). Make sure to update database endpoint since this is crucial for moving forward. We also suggest creating empty database for runnign tests and specifying it in `settings.toml` testing section.
-4. Update database to latest migration (keep in mind that migraiton id here might be outdated by now and you should always check [alembic/versions/](alembic/versions/) for latest migration):
+4. Update database to latest migration:
    ```sh
-   alembic upgrade 0c8a96ac77c9
+   alembic upgrade head
    ```
-6. Enable ltree extension in PostgreSQL by running (we need it for comments logic):
+5. Enable ltree extension in PostgreSQL by running (we need it for comments logic):
    ```sql
    CREATE EXTENSION IF NOT EXISTS ltree;
    ```
-7. Now let's run tests to make sure everything is setup properly:
+6. Now let's run tests to make sure everything is setup properly:
    ```sh
    pytest
    ```
-8. If tests from previous step completed without any issues - congrats, now you can launch Hikka backend locally:
+7. If tests from previous step completed without any issues - congrats, now you can launch Hikka backend locally:
    ```sh
    uvicorn run:app --reload --port=8888
    ```
@@ -71,6 +71,7 @@ If you have a suggestion that would make this better, please fork the repo and c
 5. Open a Pull Request
 
 Here is couple suggestions which would ensure smooth cooperation:
+
 - Write clean and concise code, we recommend using tools like [ruff](https://docs.astral.sh) to ensure code quality. Here is how we usually check code quality `ruff check app/`.
 - Always write tests for your code, this would help us to review and accept your code faster.
 - When creating pull request please write detailed explanation. This would make our work easier ;)

--- a/app/anime/service.py
+++ b/app/anime/service.py
@@ -32,7 +32,7 @@ async def get_anime_info_by_slug(
     return await session.scalar(
         select(Anime)
         .filter(
-            func.lower(Anime.slug) == slug.lower(),  # type: ignore
+            Anime.slug == slug.lower(),  # type: ignore
             Anime.deleted == False,  # noqa: E712
         )
         .options(

--- a/app/characters/service.py
+++ b/app/characters/service.py
@@ -25,7 +25,7 @@ async def get_character_by_slug(
     session: AsyncSession, slug: str
 ) -> Character | None:
     return await session.scalar(
-        select(Character).filter(func.lower(Character.slug) == slug.lower())
+        select(Character).filter(Character.slug == slug.lower())
     )
 
 

--- a/app/companies/service.py
+++ b/app/companies/service.py
@@ -11,7 +11,7 @@ async def get_company_by_slug(
     session: AsyncSession, slug: str
 ) -> Company | None:
     return await session.scalar(
-        select(Company).filter(func.lower(Company.slug) == slug.lower())
+        select(Company).filter(Company.slug == slug.lower())
     )
 
 

--- a/app/manga/service.py
+++ b/app/manga/service.py
@@ -27,7 +27,7 @@ async def get_manga_info_by_slug(
     return await session.scalar(
         select(Manga)
         .filter(
-            func.lower(Manga.slug) == slug.lower(),
+            Manga.slug == slug.lower(),
             Manga.deleted == False,  # noqa: E712
         )
         .options(
@@ -41,7 +41,7 @@ async def get_manga_info_by_slug(
 async def get_manga_by_slug(session: AsyncSession, slug: str) -> Manga | None:
     return await session.scalar(
         select(Manga).filter(
-            func.lower(Manga.slug) == slug.lower(),
+            Manga.slug == slug.lower(),
             Manga.deleted == False,  # noqa: E712
         )
     )

--- a/app/models/mixins.py
+++ b/app/models/mixins.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.orm import query_expression
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import declared_attr
+from sqlalchemy.orm import validates
 from sqlalchemy.orm import Mapped
 from sqlalchemy import String
 from datetime import datetime
@@ -32,6 +33,10 @@ class ContentMixin:
 
 class SlugMixin:
     slug: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+
+    @validates("slug")
+    def ensure_lowercase(self, key, value):
+        return value.lower()
 
 
 class UpdatedMixin:

--- a/app/novel/service.py
+++ b/app/novel/service.py
@@ -27,7 +27,7 @@ async def get_novel_info_by_slug(
     return await session.scalar(
         select(Novel)
         .filter(
-            func.lower(Novel.slug) == slug.lower(),
+            Novel.slug == slug.lower(),
             Novel.deleted == False,  # noqa: E712
         )
         .options(
@@ -41,7 +41,7 @@ async def get_novel_info_by_slug(
 async def get_novel_by_slug(session: AsyncSession, slug: str) -> Novel | None:
     return await session.scalar(
         select(Novel).filter(
-            func.lower(Novel.slug) == slug.lower(),
+            Novel.slug == slug.lower(),
             Novel.deleted == False,  # noqa: E712
         )
     )

--- a/app/people/service.py
+++ b/app/people/service.py
@@ -23,7 +23,7 @@ from app.models import (
 
 async def get_person_by_slug(session: AsyncSession, slug: str) -> Person | None:
     return await session.scalar(
-        select(Person).filter(func.lower(Person.slug) == slug.lower())
+        select(Person).filter(Person.slug == slug.lower())
     )
 
 

--- a/app/service.py
+++ b/app/service.py
@@ -187,7 +187,7 @@ async def get_user_by_email(session: AsyncSession, email: str) -> User | None:
 async def get_anime_by_slug(session: AsyncSession, slug: str) -> Anime | None:
     return await session.scalar(
         select(Anime).filter(
-            func.lower(Anime.slug) == slug.lower(),
+            Anime.slug == slug.lower(),
             Anime.deleted == False,  # noqa: E712
         )
     )

--- a/tests/database/test_slug_constraints.py
+++ b/tests/database/test_slug_constraints.py
@@ -1,0 +1,72 @@
+from app.models import Anime, Manga, Novel
+from sqlalchemy import select
+import helpers
+
+
+async def test_anime_slug_lowercase(test_session, aggregator_anime):
+    anime = await test_session.scalar(select(Anime).limit(1))
+    args = helpers.model_to_dict(anime)
+
+    await test_session.delete(anime)
+    await test_session.commit()
+
+    args["slug"] = "THIS-SLUG-IS-UPPERCASE"
+
+    # Roundabout way of creating an Anime object in order to not break the test
+    # whenever the model is changed
+    anime = Anime(**args)
+
+    test_session.add(anime)
+    await test_session.commit()
+
+    anime = await test_session.scalar(
+        select(Anime).filter(Anime.slug == "this-slug-is-uppercase")
+    )
+
+    assert anime is not None
+
+
+async def test_manga_slug_lowercase(test_session, aggregator_manga):
+    manga = await test_session.scalar(select(Manga).limit(1))
+    args = helpers.model_to_dict(manga)
+
+    await test_session.delete(manga)
+    await test_session.commit()
+
+    args["slug"] = "THIS-SLUG-IS-UPPERCASE"
+
+    # Roundabout way of creating a Manga object in order to not break the test
+    # whenever the model is changed
+    manga = Manga(**args)
+
+    test_session.add(manga)
+    await test_session.commit()
+
+    manga = await test_session.scalar(
+        select(Manga).filter(Manga.slug == "this-slug-is-uppercase")
+    )
+
+    assert manga is not None
+
+
+async def test_novel_slug_lowercase(test_session, aggregator_novel):
+    novel = await test_session.scalar(select(Novel).limit(1))
+    args = helpers.model_to_dict(novel)
+
+    await test_session.delete(novel)
+    await test_session.commit()
+
+    args["slug"] = "THIS-SLUG-IS-UPPERCASE"
+
+    # Roundabout way of creating a Novel object in order to not break the test
+    # whenever the model is changed
+    novel = Novel(**args)
+
+    test_session.add(novel)
+    await test_session.commit()
+
+    novel = await test_session.scalar(
+        select(Novel).filter(Novel.slug == "this-slug-is-uppercase")
+    )
+
+    assert novel is not None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,7 @@
 from app.models import User, UserOAuth, AuthToken, Client
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.inspection import inspect
 from app.utils import new_token, utcnow
 from datetime import timedelta
 from sqlalchemy import select
@@ -114,3 +116,10 @@ async def create_client(
     await session.commit()
 
     return client
+
+
+def model_to_dict(model: DeclarativeBase) -> dict:
+    return {
+        col.key: getattr(model, col.key)
+        for col in inspect(model).mapper.column_attrs
+    }


### PR DESCRIPTION
This PR removes the lower() function from slug related queries in order to use the existing slug index correctly.
Before:
![зображення](https://github.com/user-attachments/assets/3e354909-9e03-478e-912c-1d7eb21e7d5b)
After:
![зображення](https://github.com/user-attachments/assets/cba45008-f146-4eb0-8b7e-282c0819be99)

Searching rows by slug is very common and affects a lot of content types - anime, manga, novels, characters and people. We're doing a table scan each time we need to get anime/manga/novels etc by slug, rather than using an index which makes the query basically free. This PR optimizes these queries by 10-60x, depending on the content type.

To make sure that the slug always remains lowercase, I've added a validator to the SlugMixin that ensures that the slug is lowercased whenever we insert/update rows with this mixin. I've also added a couple of tests that make sure that this behaviour doesn't get broken in the future.