### PR TITLE
Add editing of the genres list of the content

### DIFF
--- a/app/edit/dependencies.py
+++ b/app/edit/dependencies.py
@@ -33,7 +33,7 @@ async def validate_edit_genres(
 ) -> EditArgs:
     """Validate genres if they are present in the 'after' payload"""
 
-    if "genres" in args.after and args.after["genres"] is not None:
+    if args.after.get("genres") is not None:
         submitted_genres = list(set(args.after["genres"]))
         if len(submitted_genres) > 0:
             valid_genres_count = await genres_count(session, submitted_genres)

--- a/app/edit/dependencies.py
+++ b/app/edit/dependencies.py
@@ -27,6 +27,20 @@ from .schemas import (
     EditArgs,
 )
 
+async def validate_edit_genres(
+    args: EditArgs,
+    session: AsyncSession = Depends(get_session),
+) -> EditArgs:
+    """Validate genres if they are present in the 'after' payload"""
+
+    if "genres" in args.after and args.after["genres"] is not None:
+        submitted_genres = list(set(args.after["genres"]))
+        if len(submitted_genres) > 0:
+            valid_genres_count = await genres_count(session, submitted_genres)
+            if valid_genres_count != len(submitted_genres):
+                raise Abort("edit", "invalid-genre")
+
+    return args
 
 async def validate_edit_search_args(
     args: EditSearchArgs,
@@ -139,43 +153,25 @@ async def validate_content(
 
 async def validate_edit_create_args(
     content_type: EditContentTypeEnum,
-    args: EditArgs,
-    session: AsyncSession = Depends(get_session), 
+    args: EditArgs = Depends(validate_edit_genres), 
 ) -> EditArgs:
     """Validate create edit args"""
 
     if not utils.check_edit_schema(content_type, args):
         raise Abort("edit", "bad-edit")
 
-    # Validate genres if they are present in the 'after' payload
-    if "genres" in args.after and args.after["genres"] is not None:
-        submitted_genres = list(set(args.after["genres"]))
-        if len(submitted_genres) > 0:
-            valid_genres_count = await genres_count(session, submitted_genres)
-            if valid_genres_count != len(submitted_genres):
-                raise Abort("edit", "invalid-genre")
-
     return args
 
 
 async def validate_edit_update_args(
-    args: EditArgs,
+    args: EditArgs = Depends(validate_edit_genres),
     edit: Edit = Depends(validate_edit_update),
     author: User = Depends(auth_required()),
-    session: AsyncSession = Depends(get_session),
 ) -> EditArgs:
     """Validate update edit args"""
 
     if not utils.check_edit_schema(edit.content_type, args):
         raise Abort("edit", "bad-edit")
-        
-    # Validate genres if they are present in the 'after' payload
-    if "genres" in args.after and args.after["genres"] is not None:
-        submitted_genres = list(set(args.after["genres"]))
-        if len(submitted_genres) > 0:
-            valid_genres_count = await genres_count(session, submitted_genres)
-            if valid_genres_count != len(submitted_genres):
-                raise Abort("edit", "invalid-genre")
 
     args.after = utils.check_after(args.after, edit.content)
     if len(args.after) == 0:

--- a/app/edit/schemas.py
+++ b/app/edit/schemas.py
@@ -107,6 +107,7 @@ class AnimeEditArgs(CustomModel):
     synopsis_en: str | None = Field(None, examples=["..."])
     synopsis_ua: str | None = Field(None, examples=["..."])
     synonyms: list[str] | None = None
+    genres: list[str] | None = None
 
     title_ja: str | None = Field(
         None,
@@ -131,6 +132,7 @@ class MangaEditArgs(CustomModel):
     synopsis_en: str | None = Field(None, examples=["..."])
     synopsis_ua: str | None = Field(None, examples=["..."])
     synonyms: list[str] | None = None
+    genres: list[str] | None = None
     title_original: str | None = None
     title_en: str | None = None
     title_ua: str | None = None
@@ -140,6 +142,7 @@ class NovelEditArgs(CustomModel):
     synopsis_en: str | None = Field(None, examples=["..."])
     synopsis_ua: str | None = Field(None, examples=["..."])
     synonyms: list[str] | None = None
+    genres: list[str] | None = None
     title_original: str | None = None
     title_en: str | None = None
     title_ua: str | None = None

--- a/app/edit/service.py
+++ b/app/edit/service.py
@@ -293,7 +293,7 @@ async def accept_pending_edit(
     before = {}
 
     if "genres" in edit.after:
-        new_genre_slugs = edit.after.pop("genres")
+        new_genre_slugs = edit.after["genres"]
         
         before["genres"] = [genre.slug for genre in content.genres]
         
@@ -310,6 +310,9 @@ async def accept_pending_edit(
                 content.ignored_fields.append("genres")
 
     for key, value in edit.after.items():
+        if key == "genres":
+            continue
+
         before[key] = getattr(content, key)
         setattr(content, key, value)
 

--- a/app/edit/service.py
+++ b/app/edit/service.py
@@ -85,9 +85,9 @@ async def get_edit(session: AsyncSession, edit_id: int) -> Edit | None:
         .options(
             joinedload(CharacterEdit.content),
             joinedload(PersonEdit.content),
-            joinedload(AnimeEdit.content),
-            joinedload(MangaEdit.content),
-            joinedload(NovelEdit.content),
+            joinedload(AnimeEdit.content).joinedload(Anime.genres),
+            joinedload(MangaEdit.content).joinedload(Manga.genres),
+            joinedload(NovelEdit.content).joinedload(Novel.genres),
         )
     )
 

--- a/app/edit/utils.py
+++ b/app/edit/utils.py
@@ -55,6 +55,13 @@ def check_after(after, content):
     pop_list = []
 
     for key, value in after.items():
+        # Add special handling for genres
+        if key == "genres":
+            current_genres = sorted([genre.slug for genre in content.genres])
+            if current_genres == sorted(value):
+                pop_list.append(key)
+            continue # Continue to next item in loop
+
         if getattr(content, key) == value:
             pop_list.append(key)
 
@@ -68,6 +75,11 @@ def calculate_before(content, after):
     before = {}
 
     for key, _ in after.items():
+        # Add special handling for genres
+        if key == "genres":
+            before[key] = [genre.slug for genre in content.genres]
+            continue # Continue to next item in loop
+            
         before[key] = getattr(content, key)
 
     return before

--- a/app/errors.py
+++ b/app/errors.py
@@ -76,6 +76,7 @@ errors = {
     "edit": {
         "rate-limit": ["You have reached the edit rate limit, try later", 429],
         "missing-content-type": ["You must specify content type", 400],
+        "invalid-genre": ["One or more genres are invalid", 400],
         "not-pending": ["Only pending edit can be changed", 400],
         "moderator-not-found": ["Moderator not found", 404],
         "not-author": ["Only author can modify edit", 400],

--- a/app/service.py
+++ b/app/service.py
@@ -125,6 +125,13 @@ async def get_content_by_slug(
     else:
         query = query.filter(content_model.slug == slug)
 
+    if content_type in [
+        constants.CONTENT_ANIME,
+        constants.CONTENT_MANGA,
+        constants.CONTENT_NOVEL,
+    ]:
+        query = query.options(selectinload(content_model.genres))
+
     return await session.scalar(query)
 
 


### PR DESCRIPTION
This commit introduces the functionality for users to suggest changes to the genres of Anime, Manga, and Novel content types through the edit system. This enhances data accuracy by allowing the community to correct and update genre information.

Key changes include:
- Updated `EditArgs` schemas to accept a `genres` field, which is a list of genre slugs.
- Added validation in `edit/dependencies.py` to ensure all submitted genre slugs are valid before creating or updating an edit.
- Implemented the core logic in `accept_pending_edit` to correctly update the many-to-many relationship between the content and its genres.