### PR TITLE
Add support for devenv developer environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ pyrightconfig.json
 .vscode/*
 
 .profile_info
+
+# Devenv
+.devenv*
+.direnv
+devenv.local.nix

--- a/devenv.lock
+++ b/devenv.lock
@@ -1,0 +1,139 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1763748595,
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "575f7c532a6940f0fe55dfb7e527312dcdab8831",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761588595,
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763741496,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "20e71a403c5de9ce5bd799031440da9728c1cda1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762808025,
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761313199,
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "d1c30452ebecfc55185ae6d1c983c09da0c274ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763677049,
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "159d63dc49a4b12bf85fe0e83011a8b69ba1bcb0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python",
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,0 +1,105 @@
+{ pkgs, lib, config, inputs, ... }:
+
+let
+  dbUser = "user";
+  dbPass = "password";
+  dbName = "hikka";
+
+  meilisearch-1-4-2 = pkgs.stdenv.mkDerivation (finalAttrs: {
+    pname = "meilisearch";
+    version = "1.4.2";
+
+    src = let
+      system = pkgs.stdenv.hostPlatform.system;
+      selectSource = url: hash: pkgs.fetchurl { inherit url hash; };
+      sources = {
+        "x86_64-linux" = selectSource
+          "https://github.com/meilisearch/meilisearch/releases/download/v${finalAttrs.version}/meilisearch-linux-amd64"
+          "sha256-tUuaziE7DUVVjF0OeXEPcYtj0uKcGQ+5W+Adwn6xylw=";
+          
+        "aarch64-darwin" = selectSource
+          "https://github.com/meilisearch/meilisearch/releases/download/v${finalAttrs.version}/meilisearch-macos-apple-silicon"
+          "sha256-jLeeSWGDtpls0Va7mUA7JxU05oW1qRzp6ie0f5V3TGI=";
+      };
+    in sources.${system} or (throw "Unsupported system: ${system}");
+
+    dontUnpack = true;
+
+    nativeBuildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ 
+      pkgs.autoPatchelfHook 
+    ];
+
+    buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ 
+      pkgs.stdenv.cc.cc.lib 
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      install -m755 -D $src $out/bin/meilisearch
+      runHook postInstall
+    '';
+
+    meta = with lib; {
+      description = "A lightning-fast search engine that fits effortlessly into your apps, websites, and workflow";
+      homepage = "https://meilisearch.com";
+      license = licenses.mit; 
+      platforms = [ "x86_64-linux" "aarch64-darwin" ];
+      mainProgram = "meilisearch";
+      maintainers = [ Okashichan ];
+    };
+  });
+in
+{
+  # https://devenv.sh/basics/
+  # https://devenv.sh/packages/
+  packages = [ pkgs.git pkgs.postgresql pkgs.postgresql.pg_config ];
+
+  # https://devenv.sh/languages/
+  languages.python = {
+    enable = true;
+    
+    # I'm not sure but eh
+    version = lib.trim (builtins.readFile ./.python-version);
+    
+    poetry = {
+      enable = true;
+      install.enable = true;
+    };
+  };
+
+  # https://devenv.sh/scripts/
+  scripts.alembic-upgrade.exec = "alembic upgrade head";
+
+  # https://devenv.sh/processes/
+  processes.fastapi.exec = "uvicorn run:app --reload --port=8888";
+
+  # https://devenv.sh/services/
+  services = {
+    meilisearch = {
+      enable = true;
+      package = meilisearch-1-4-2;
+      listenPort = 8800;
+    }; 
+  };
+
+  services.postgres = {
+    enable = true;
+    listen_addresses = "localhost";
+    initialDatabases = [{ name = dbName; user = dbUser; pass = dbPass; }];
+    initialScript = ''
+      CREATE EXTENSION IF NOT EXISTS ltree;
+      ALTER USER "${dbUser}" WITH SUPERUSER;
+    '';
+  };
+
+  enterShell = ''
+    python --version
+    postgres --version
+    alembic --version
+    meilisearch --version
+  '';
+
+  env.DATABASE_URL = "postgresql+asyncpg://${dbUser}:${dbPass}@localhost:5432/${dbName}";
+
+  # See full reference at https://devenv.sh/reference/options/
+}

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,0 +1,9 @@
+inputs:
+  nixpkgs:
+    url: github:cachix/devenv-nixpkgs/rolling
+  nixpkgs-python:
+    url: github:cachix/nixpkgs-python
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
+allowUnfree: true


### PR DESCRIPTION
Basically, ready-to-develop after filling all the necessary API keys and such (I guess?)
Alongside the [alembic-upgrade](https://github.com/Okashichan/hikka/blob/07abdbd66299a71e1b0c9cc0099336f141ee884b/devenv.nix#L71) script, a DB dump importing one should probably be added too

Learn about devenv here: https://devenv.sh/getting-started

<img width="1034" height="332" alt="Знімок екрана з 2025-11-22 02-34-00" src="https://github.com/user-attachments/assets/1650481b-b41b-4091-a3e3-38772436ab8b" />
<img width="1917" height="1000" alt="Знімок екрана з 2025-11-22 02-33-36" src="https://github.com/user-attachments/assets/5e3ae375-716b-4f81-85c2-9445e42c3e2c" />

<img width="323" height="55" alt="Знімок екрана з 2025-11-22 02-47-17" src="https://github.com/user-attachments/assets/2c5ba632-27e4-4ddb-ac62-1f885f295074" />
