### PR TITLE
Add tag filter for collections

### DIFF
--- a/app/collections/schemas.py
+++ b/app/collections/schemas.py
@@ -36,6 +36,7 @@ class CollectionsListArgs(CustomModel):
     content_type: ContentTypeEnum | None = None
     author: str | None = None
     only_public: bool = True
+    tags: list[str] = Field([])
 
     @field_validator("sort")
     def validate_sort(cls, sort_list):

--- a/app/collections/schemas.py
+++ b/app/collections/schemas.py
@@ -36,7 +36,7 @@ class CollectionsListArgs(CustomModel):
     content_type: ContentTypeEnum | None = None
     author: str | None = None
     only_public: bool = True
-    tags: list[str] = Field([])
+    tags: list[str] = Field([], max_length=3)
 
     @field_validator("sort")
     def validate_sort(cls, sort_list):

--- a/app/collections/service.py
+++ b/app/collections/service.py
@@ -129,6 +129,16 @@ async def collections_list_filter(
     if args.content_type:
         query = query.filter(Collection.content_type == args.content_type)
 
+    if len(args.tags) > 0:
+        query = query.filter(
+            and_(
+                *[
+                    Collection.tags.any(name)
+                    for name in args.tags
+                ]
+            )
+        )
+
     if args.only_public:
         visibility = [constants.COLLECTION_PUBLIC]
 

--- a/tests/collections/test_collections_list.py
+++ b/tests/collections/test_collections_list.py
@@ -39,7 +39,7 @@ async def test_collections_list(
         client,
         get_test_token,
         {
-            "tags": [],
+            "tags": ["first", "tag"],
             "title": "Random anime collection",
             "description": "Description",
             "content_type": "anime",
@@ -66,7 +66,7 @@ async def test_collections_list(
         client,
         get_test_token,
         {
-            "tags": [],
+            "tags": ["second", "tag"],
             "title": "Random people collection",
             "description": "Description",
             "content_type": "person",
@@ -121,3 +121,15 @@ async def test_collections_list(
         response.json()["list"][0]["collection"][5]["content"]["slug"]
         == people_slugs[5]
     )
+
+    # Get collections with tags
+    response = await request_collections(client, filters={'tags': ['tag']})
+
+    # There should be 2 returned, as both collections have 'tag' in the tags
+    assert len(response.json()["list"]) == 2
+
+    response = await request_collections(client, filters={'tags': ['second']})
+    assert len(response.json()["list"]) == 1
+
+    response = await request_collections(client, filters={'tags': ['first']})
+    assert len(response.json()["list"]) == 1


### PR DESCRIPTION
This PR introduces tag filtering for collections 

Changes:
- `CollectionsListArgs` now accepts `tags` as a filter
- The `collections` service now includes this in the query filter
- Tests have been updated to use tags and new assertions have been created