### PR TITLE
devenv rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Install [devenv](https://devenv.sh/getting-started/) before proceeding.
 
 ---
 
-#### Option B — devenv (recommended)
+#### Option B — devenv
 
 [devenv](https://devenv.sh) provides a fully reproducible development environment that automatically manages PostgreSQL, Meilisearch, and all dependencies for you — no manual configuration needed.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This guide assumes you already have PostgreSQL installed and database named `hik
 
 Optionally you also need to install Meilisearch [1.4.2](https://github.com/meilisearch/meilisearch/releases/tag/v1.4.2) to work with search. Please note this exact version must be installed because newer versions most likely contain API breaking changes.
 
-[Option B — devenv (recommended)](#option-b--devenv-recommended)
+[Option B — devenv](#option-b--devenv)
 
 **Prerequisites** 
 

--- a/README.md
+++ b/README.md
@@ -20,43 +20,105 @@ And more!
 
 ## Getting Started
 
-In order to get Hikka up and running on your local machine you must follow this steps.
-
-### Prerequisites
-
-This guide assumes you already have PostgreSQL installed and database named `hikka` created. For development you would also need [Poetry](https://python-poetry.org).
-
-Optionally you also need to install Meilisearch [1.4.2](https://github.com/meilisearch/meilisearch/releases/tag/v1.4.2) to work with search. Please note this exact version must be installed because newer versions most likely contain API breaking changes.
-
-### Installation
+In order to get Hikka up and running on your local machine you must follow the following.
 
 1. Clone this repository and enter project directory:
    ```sh
    git clone https://github.com/volbil/hikka.git
    cd hikka
    ```
-2. Create virtual environment and install dependencies using Poetry:
+2. Then choose one of the following installation methods:
+
+[Option A — poetry (manual setup)](#option-a--poetry-manual-setup)
+
+**Prerequisites**
+
+This guide assumes you already have PostgreSQL installed and database named `hikka` created. For development you would also need [Poetry](https://python-poetry.org).
+
+Optionally you also need to install Meilisearch [1.4.2](https://github.com/meilisearch/meilisearch/releases/tag/v1.4.2) to work with search. Please note this exact version must be installed because newer versions most likely contain API breaking changes.
+
+[Option B — devenv (recommended)](#option-b--devenv-recommended)
+
+**Prerequisites** 
+
+Install [devenv](https://devenv.sh/getting-started/) before proceeding.
+
+---
+
+#### Option A — poetry (manual setup)
+
+1. Create virtual environment and install dependencies using Poetry:
    ```sh
    poetry shell
    poetry install
    ```
-3. Create `alembic.ini` and `settings.toml` files in project root directory, example configs can be found in [docs/](docs/). Make sure to update database endpoint since this is crucial for moving forward. We also suggest creating empty database for runnign tests and specifying it in `settings.toml` testing section.
-4. Update database to latest migration:
+2. Create `alembic.ini` and `settings.toml` files in project root directory, example configs can be found in [docs/](docs/). Make sure to update database endpoint since this is crucial for moving forward. We also suggest creating empty database for runnign tests and specifying it in `settings.toml` testing section.
+3. Update database to latest migration:
    ```sh
    alembic upgrade head
    ```
-5. Enable ltree extension in PostgreSQL by running (we need it for comments logic):
+4. Enable ltree extension in PostgreSQL by running (we need it for comments logic):
    ```sql
    CREATE EXTENSION IF NOT EXISTS ltree;
    ```
-6. Now let's run tests to make sure everything is setup properly:
+5. Now let's run tests to make sure everything is setup properly:
    ```sh
    pytest
    ```
-7. If tests from previous step completed without any issues - congrats, now you can launch Hikka backend locally:
+6. If tests from previous step completed without any issues - congrats, now you can launch Hikka backend locally:
    ```sh
    uvicorn run:app --reload --port=8888
    ```
+
+---
+
+#### Option B — devenv (recommended)
+
+[devenv](https://devenv.sh) provides a fully reproducible development environment that automatically manages PostgreSQL, Meilisearch, and all dependencies for you — no manual configuration needed.
+
+
+1. Start all services (FastAPI, PostgreSQL, Meilisearch, pgweb):
+   ```sh
+   devenv up
+   ```
+   This launches the entire project stack. The following ports will be used:
+   | Service      | Port |
+   |--------------|------|
+   | FastAPI      | 8888 |
+   | PostgreSQL   | 5432 |
+   | Meilisearch  | 8800 |
+   | pgweb        | 8081 |
+2. In a separate terminal, enter the dev shell to access project scripts:
+   ```sh
+   devenv shell
+   ```
+   Inside the shell, the following commands are available:
+   | Command | Description |
+   |---|---|
+   | `run-test` | Run the test suite |
+   | `alembic-upgrade` | Apply all pending database migrations |
+   | `db-load-sample <hikka-sample.sql>` | Load a sample SQL dump and run migrations |
+
+##### Customizing your local environment
+
+You can override any devenv settings locally without touching the shared `devenv.nix`. Create a `devenv.local.nix` file in the project root — it is gitignored and intended for personal adjustments.
+
+For example:
+```nix
+{ pkgs, lib, config, inputs, ... }:
+{
+  services.postgres.port = lib.mkForce 5433;
+  services.meilisearch.listenPort = lib.mkForce 8900;
+
+  files."settings.toml".toml.default = {
+    backend.origins = lib.mkForce [ "http://localhost:3000" ];
+    meilisearch.api_key = lib.mkForce "my-local-key";
+    profiling.enabled = lib.mkForce false;
+  };
+}
+```
+
+> **Note:** `devenv.local.nix` is merged on top of `devenv.nix`, so you only need to specify the things you want to change.
 
 ## Contributing
 

--- a/app/sync/search/anime.py
+++ b/app/sync/search/anime.py
@@ -196,7 +196,7 @@ async def meilisearch_populate(session: AsyncSession):
             documents = await anime_documents(session, limit, offset)
 
             if len(documents) > 0:
-                await index.add_documents(documents)
+                await index.add_documents(documents, primary_key="id")
 
         delete_document_ids = await anime_document_ids_delete(session)
 

--- a/app/sync/search/manga.py
+++ b/app/sync/search/manga.py
@@ -162,7 +162,7 @@ async def meilisearch_populate(session: AsyncSession):
             documents = await manga_documents(session, limit, offset)
 
             if len(documents) > 0:
-                await index.add_documents(documents)
+                await index.add_documents(documents, primary_key="id")
 
         delete_document_ids = await manga_document_ids_delete(session)
 

--- a/app/sync/search/novel.py
+++ b/app/sync/search/novel.py
@@ -162,7 +162,7 @@ async def meilisearch_populate(session: AsyncSession):
             documents = await novel_documents(session, limit, offset)
 
             if len(documents) > 0:
-                await index.add_documents(documents)
+                await index.add_documents(documents, primary_key="id")
 
         delete_document_ids = await novel_document_ids_delete(session)
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,10 +3,10 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1763748595,
+        "lastModified": 1773034036,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "575f7c532a6940f0fe55dfb7e527312dcdab8831",
+        "rev": "32c9ecdacbd7093ae096e5ca312c4497e3758159",
         "type": "github"
       },
       "original": {
@@ -19,14 +19,14 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -34,10 +34,10 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
+        "lastModified": 1767039857,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -55,10 +55,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1763741496,
+        "lastModified": 1772893680,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "20e71a403c5de9ce5bd799031440da9728c1cda1",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
         "type": "github"
       },
       "original": {
@@ -88,17 +88,50 @@
       }
     },
     "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1761313199,
+        "lastModified": 1772749504,
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "d1c30452ebecfc55185ae6d1c983c09da0c274ff",
+        "rev": "08543693199362c1fddb8f52126030d0d374ba2e",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "ref": "rolling",
         "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-meilisearch": {
+      "locked": {
+        "lastModified": 1727390236,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ab7b6889ae9d484eed2876868209e33eb262511d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ab7b6889ae9d484eed2876868209e33eb262511d",
+        "type": "github"
+      }
+    },
+    "nixpkgs-postgres": {
+      "locked": {
+        "lastModified": 1723603349,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "daf7bb95821b789db24fc1ac21f613db0c1bf2cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "daf7bb95821b789db24fc1ac21f613db0c1bf2cb",
         "type": "github"
       }
     },
@@ -110,10 +143,10 @@
         ]
       },
       "locked": {
-        "lastModified": 1763677049,
+        "lastModified": 1772559541,
         "owner": "cachix",
         "repo": "nixpkgs-python",
-        "rev": "159d63dc49a4b12bf85fe0e83011a8b69ba1bcb0",
+        "rev": "188ffc273f679a2d95a1c8aba0be083545417bdd",
         "type": "github"
       },
       "original": {
@@ -122,11 +155,30 @@
         "type": "github"
       }
     },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769922788,
+        "narHash": "sha256-H3AfG4ObMDTkTJYkd8cz1/RbY9LatN5Mk4UF48VuSXc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "207d15f1a6603226e1e223dc79ac29c7846da32e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-meilisearch": "nixpkgs-meilisearch",
+        "nixpkgs-postgres": "nixpkgs-postgres",
         "nixpkgs-python": "nixpkgs-python",
         "pre-commit-hooks": [
           "git-hooks"

--- a/devenv.nix
+++ b/devenv.nix
@@ -50,12 +50,7 @@ in
         exit 1
       fi
 
-      psql \
-        -h localhost \
-        -p ${toString ports.postgres} \
-        -U ${db.user} \
-        -d ${db.name} \
-        -f $1
+      psql ${credsString} -f $1
 
       alembic-upgrade
     '';

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,58 +1,29 @@
 { pkgs, lib, config, inputs, ... }:
 
 let
-  dbUser = "user";
-  dbPass = "password";
-  dbName = "hikka";
+  db = {
+    user = "user";
+    pass = "password";
+    name = "hikka";
+    connectionString = "postgresql+asyncpg://${db.user}:${db.pass}@localhost:${toString ports.postgres}/${db.name}";
+  };
 
-  meilisearch-1-4-2 = pkgs.stdenv.mkDerivation (finalAttrs: {
-    pname = "meilisearch";
-    version = "1.4.2";
+  credsString = "-h localhost -p ${toString ports.postgres} -U ${db.user} -d ${db.name}";
 
-    src = let
-      system = pkgs.stdenv.hostPlatform.system;
-      selectSource = url: hash: pkgs.fetchurl { inherit url hash; };
-      sources = {
-        "x86_64-linux" = selectSource
-          "https://github.com/meilisearch/meilisearch/releases/download/v${finalAttrs.version}/meilisearch-linux-amd64"
-          "sha256-tUuaziE7DUVVjF0OeXEPcYtj0uKcGQ+5W+Adwn6xylw=";
-          
-        "aarch64-darwin" = selectSource
-          "https://github.com/meilisearch/meilisearch/releases/download/v${finalAttrs.version}/meilisearch-macos-apple-silicon"
-          "sha256-jLeeSWGDtpls0Va7mUA7JxU05oW1qRzp6ie0f5V3TGI=";
-      };
-    in sources.${system} or (throw "Unsupported system: ${system}");
+  ports = {
+    fastapi = 8888;
+    postgres = 5432;
+    meilisearch = 8800;
+    pgweb = 8081;
+  };
 
-    dontUnpack = true;
-
-    nativeBuildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ 
-      pkgs.autoPatchelfHook 
-    ];
-
-    buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux [ 
-      pkgs.stdenv.cc.cc.lib 
-    ];
-
-    installPhase = ''
-      runHook preInstall
-      install -m755 -D $src $out/bin/meilisearch
-      runHook postInstall
-    '';
-
-    meta = with lib; {
-      description = "A lightning-fast search engine that fits effortlessly into your apps, websites, and workflow";
-      homepage = "https://meilisearch.com";
-      license = licenses.mit; 
-      platforms = [ "x86_64-linux" "aarch64-darwin" ];
-      mainProgram = "meilisearch";
-      maintainers = [ Okashichan ];
-    };
-  });
+  postgres-16-3 = inputs.nixpkgs-postgres.legacyPackages.${pkgs.stdenv.system}.postgresql_16;
+  meilisearch-1-9 = inputs.nixpkgs-meilisearch.legacyPackages.${pkgs.stdenv.system}.meilisearch;
 in
 {
   # https://devenv.sh/basics/
   # https://devenv.sh/packages/
-  packages = [ pkgs.git pkgs.postgresql pkgs.postgresql.pg_config ];
+  packages = with pkgs; [ git pgweb ];
 
   # https://devenv.sh/languages/
   languages.python = {
@@ -61,45 +32,291 @@ in
     # I'm not sure but eh
     version = lib.trim (builtins.readFile ./.python-version);
     
-    poetry = {
+    uv = {
       enable = true;
-      install.enable = true;
+      sync.enable = true;
     };
   };
 
   # https://devenv.sh/scripts/
-  scripts.alembic-upgrade.exec = "alembic upgrade head";
+  scripts = {
+    run-test.exec = "uv run pytest";
+
+    alembic-upgrade.exec = "uv run alembic upgrade head";
+
+    db-load-sample.exec = ''
+      if [ -z "$1" ]; then
+        echo "Usage: db-load-sample <hikka-sample.sql>"
+        exit 1
+      fi
+
+      psql \
+        -h localhost \
+        -p ${toString ports.postgres} \
+        -U ${db.user} \
+        -d ${db.name} \
+        -f $1
+
+      alembic-upgrade
+    '';
+  };
 
   # https://devenv.sh/processes/
-  processes.fastapi.exec = "uvicorn run:app --reload --port=8888";
+  processes = {
+    fastapi.exec = ''
+      uv run uvicorn \
+      run:app \
+      --reload \
+      --port=${toString ports.fastapi}
+    '';
+    
+    sync.exec = ''
+      while ! pg_isready ${credsString}; do 
+        sleep 1
+      done
+      
+      TABLE_COUNT=$(psql \
+        ${credsString} \
+        -tAc "SELECT count(*) \
+        FROM information_schema.tables \
+        WHERE table_schema = 'public';")
+
+      if [ "$TABLE_COUNT" -eq "0" ]; then
+        echo "ERROR: Database is empty. Run 'db-load-sample <hikka-sample.sql>' and restart." >&2
+        exit 0
+      fi
+
+      uv run sync.py
+    '';
+
+    pgweb.exec = ''
+      while ! pg_isready ${credsString}; do 
+        sleep 1
+      done
+
+      pgweb --bind=127.0.0.1 \
+        --listen=${toString ports.pgweb} \
+        --url="${lib.replaceStrings ["+asyncpg"] [""] db.connectionString}?sslmode=disable";
+    '';
+  };
 
   # https://devenv.sh/services/
   services = {
+    postgres = {
+      enable = true;
+      package = postgres-16-3;
+      port = ports.postgres;
+
+      listen_addresses = "localhost";
+      initialDatabases = [{ name = db.name; user = db.user; pass = db.pass; }];
+      initialScript = ''
+        CREATE EXTENSION IF NOT EXISTS ltree;
+        ALTER USER "${db.user}" WITH SUPERUSER;
+        CREATE ROLE postgres WITH LOGIN SUPERUSER;
+      '';
+    };
+
     meilisearch = {
       enable = true;
-      package = meilisearch-1-4-2;
-      listenPort = 8800;
+      package = meilisearch-1-9;
+      listenPort = ports.meilisearch;
     }; 
-  };
-
-  services.postgres = {
-    enable = true;
-    listen_addresses = "localhost";
-    initialDatabases = [{ name = dbName; user = dbUser; pass = dbPass; }];
-    initialScript = ''
-      CREATE EXTENSION IF NOT EXISTS ltree;
-      ALTER USER "${dbUser}" WITH SUPERUSER;
-    '';
   };
 
   enterShell = ''
     python --version
     postgres --version
-    alembic --version
+    uv run alembic --version
     meilisearch --version
   '';
 
-  env.DATABASE_URL = "postgresql+asyncpg://${dbUser}:${dbPass}@localhost:5432/${dbName}";
+  files = { 
+    "settings.toml".toml = {
+      default = {
+        oauth.google = {
+          client_id = "xxx.apps.googleusercontent.com";
+          client_secret = "secret";
+          redirect_uri = "http://localhost:5173";
+          enabled = true;
+        };
+
+        database = {
+          endpoint = db.connectionString;
+        };
+
+        mailgun = {
+          endpoint = "https://api.eu.mailgun.net/v3/mail.hikka.io/messages";
+          token = "token";
+          email_from = "Hikka <noreply@mail.hikka.io>";
+        };
+
+        meilisearch = {
+          url = "http://127.0.0.1:8800";
+          api_key = "xyz";
+        };
+
+        backend = {
+          plausible = "http://127.0.0.1:8000";
+          plausible_token = "TOKEN";
+          aggregator = "http://aggregator.local/database";
+          sitemap_path = "/Users/user/Work/Hikka/sitemap";
+          auth_emails = [ ];
+          origins = [
+            "http://localhost:8000"
+            "http://localhost:3000"
+            "https://hikka.io"
+          ];
+        };
+
+        backup = {
+          token = "backup_token";
+        };
+
+        captcha = {
+          secret_key = "captcha_secret";
+          site_key = "captcha_key";
+          test = "fake_captcha";
+        };
+
+        s3 = {
+          key = "s3_key";
+          secret = "s3_secret";
+          endpoint = "https://endpoint.s3.provider.com";
+          bucket = "hikka";
+        };
+
+        profiling = {
+          enabled = true;
+          trigger = "query"; # [query/all]
+          path = ".profile_info";
+          profiling_secret = "secret";
+        };
+
+        aggregator = {
+          telegram_notifications = true;
+          telegram_message_thread_id = "117779";
+          telegram_chat_id = "-1002142457586";
+          telegram_bot_token = "token";
+        };
+      };
+
+      testing = {
+        database = {
+          endpoint = "postgresql+asyncpg://user:password@localhost:5432/database-tests";
+        };
+
+        oauth.google = {
+          client_id = "xxx.apps.googleusercontent.com";
+          client_secret = "secret";
+          redirect_uri = "http://example.com/oauth/google";
+          enabled = true;
+        };
+
+        meilisearch = {
+          url = "http://127.0.0.1:9900";
+          api_key = "zyx";
+        };
+
+        backend = {
+          auth_emails = [ "user@mail.com" ];
+          origins = [ ];
+        };
+
+        backup = {
+          token = "backup_token";
+        };
+
+        captcha = {
+          secret_key = "test_secter_key";
+          site_key = "test_site_key";
+          test = "fake_captcha";
+        };
+
+        s3 = {
+          key = "FAKE_KEY";
+          secret = "FAKE_SECRET";
+          endpoint = "https://fake.s3.example.com";
+          bucket = "hikka-test";
+        };
+
+        profiling = {
+          enabled = false;
+          trigger = "query"; # [query/all]
+          path = ".profile_info";
+          profiling_secret = "secret";
+        };
+
+        aggregator = {
+          telegram_notifications = false;
+        };
+      };
+    };
+
+    "alembic.ini".ini = {
+      alembic = {
+        # Path to migration
+        script_location = "alembic";
+        
+        # Template for migration names
+        file_template = "%%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s";
+        
+        # We need this to include archived migrations
+        recursive_version_locations = true;
+        
+        # SQLAlchemy database endpoint
+        "sqlalchemy.url" = db.connectionString;
+        
+        # Misc configs
+        prepend_sys_path = ".";
+        version_path_separator = "os";
+      };
+
+      # Logging configuration (misc)
+      loggers = {
+        keys = "root,sqlalchemy,alembic";
+      };
+
+      handlers = {
+        keys = "console";
+      };
+
+      formatters = {
+        keys = "generic";
+      };
+
+      logger_root = {
+        level = "WARN";
+        handlers = "console";
+        qualname = "";
+      };
+
+      logger_sqlalchemy = {
+        level = "WARN";
+        handlers = "";
+        qualname = "sqlalchemy.engine";
+      };
+
+      logger_alembic = {
+        level = "INFO";
+        handlers = "";
+        qualname = "alembic";
+      };
+
+      handler_console = {
+        class = "StreamHandler";
+        args = "(sys.stderr,)";
+        level = "NOTSET";
+        formatter = "generic";
+      };
+
+      formatter_generic = {
+        format = "%(levelname)-5.5s [%(name)s] %(message)s";
+        datefmt = "%H:%M:%S";
+      };
+    };
+  };
+
+  env.PGPASSWORD = db.pass;
 
   # See full reference at https://devenv.sh/reference/options/
 }

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,4 +6,8 @@ inputs:
     inputs:
       nixpkgs:
         follows: nixpkgs
+  nixpkgs-meilisearch:
+    url: github:NixOS/nixpkgs/ab7b6889ae9d484eed2876868209e33eb262511d
+  nixpkgs-postgres:
+    url: github:NixOS/nixpkgs/daf7bb95821b789db24fc1ac21f613db0c1bf2cb
 allowUnfree: true


### PR DESCRIPTION
Now this devenv config fully respects deployment versioning and overwriting with `devenv.local.nix`.

I had to update some code related to [sync.py](ec79a0b6a67f37805340f8cedbd6de6c485936b5), which otherwise caused the following error with `meilisearch` after database migration, resulting in a broken state of anime, manga, and novel search:
> The primary key inference failed as the engine found 2 fields ending with id in their names: 'id' and 'mal_id'. Please specify the primary key manually using the primaryKey query parameter. Details: https://docs.meilisearch.com/errors#index_primary_key_multiple_candidates_found

`devenv up` preview:
<img width="1902" height="989" alt="image" src="https://github.com/user-attachments/assets/12114016-3534-4d85-a917-97d1b6b3b550" />

`devenv shell` preview:
<img width="1156" height="262" alt="image" src="https://github.com/user-attachments/assets/3702e04b-2097-4af9-9dc7-71a4958019fc" />

tests:
<img width="1421" height="100" alt="image" src="https://github.com/user-attachments/assets/682339eb-ee92-4a08-b5b7-103146f09053" />
