### PR TITLE
(feat): Catalog improvements

### DIFF
--- a/app/anime/router.py
+++ b/app/anime/router.py
@@ -25,6 +25,7 @@ from app.schemas import (
 )
 
 from .schemas import (
+    AnimeCatalogPaginationResponse,
     AnimeStaffPaginationResponse,
     AnimeEpisodesListResponse,
     AnimeInfoResponse,
@@ -42,7 +43,7 @@ router = APIRouter(prefix="/anime", tags=["Anime"])
 
 @router.post(
     "",
-    response_model=AnimePaginationResponse,
+    response_model=AnimeCatalogPaginationResponse,
     summary="Anime catalog",
 )
 async def search_anime(
@@ -52,27 +53,34 @@ async def search_anime(
     page: int = Depends(get_page),
     size: int = Depends(get_size),
 ):
-    if not search.query:
-        limit, offset = pagination(page, size)
-        total = await service.anime_search_total(session, search)
-        anime = await service.anime_search(
-            session, search, request_user, limit, offset
+    limit, offset = pagination(page, size)
+
+    filter_ids = []
+    if search.query:
+        meilisearch_result = await meilisearch.search(
+            constants.SEARCH_INDEX_ANIME,
+            filter=build_anime_filters(search),
+            query=search.query,
+            sort=search.sort,
+            page=page,
+            size=size,
         )
 
-        return paginated_response(anime.unique().all(), total, page, limit)
+        filter_ids = [hit["id"] for hit in meilisearch_result["list"]]
 
-    meilisearch_result = await meilisearch.search(
-        constants.SEARCH_INDEX_ANIME,
-        filter=build_anime_filters(search),
-        query=search.query,
-        sort=search.sort,
-        page=page,
-        size=size,
+        if not filter_ids:
+            return paginated_response([], 0, page, limit) 
+
+    total = await service.anime_search_total(session, search, filter_ids)
+
+    if total == 0:
+        return paginated_response([], 0, page, limit)
+
+    anime = await service.anime_search(
+        session, search, filter_ids, request_user, limit, offset
     )
 
-    return await service.anime_meilisearch_watch(
-        session, search, request_user, meilisearch_result
-    )
+    return paginated_response(anime.unique().all(), total, page, limit)
 
 
 @router.get(

--- a/app/anime/schemas.py
+++ b/app/anime/schemas.py
@@ -5,6 +5,7 @@ from typing import Literal
 from enum import Enum
 
 from app.schemas import (
+    AnimeResponseWithWatch,
     AnimeSearchArgsBase,
     AnimeVideoResponse,
     AnimeStaffResponse,
@@ -60,6 +61,16 @@ class AnimeSearchArgs(QuerySearchArgs, AnimeSearchArgsBase):
 
 
 # Responses
+class AnimeCatalogResponse(AnimeResponseWithWatch):
+    genres: list[GenreResponse]
+    studios: list[CompanyResponse]
+
+
+class AnimeCatalogPaginationResponse(CustomModel):
+    pagination: PaginationResponse
+    list: list[AnimeCatalogResponse]
+
+
 class AnimeEpisodeResponse(CustomModel):
     aired: datetime_pd | None = Field(examples=[1686088809])
     title_ua: str | None = Field(

--- a/app/anime/service.py
+++ b/app/anime/service.py
@@ -187,6 +187,7 @@ async def company_count(session: AsyncSession, slugs: list[str]):
 async def anime_search(
     session: AsyncSession,
     search: AnimeSearchArgs,
+    filter_ids: list[str],
     request_user: User | None,
     limit: int,
     offset: int,
@@ -198,9 +199,15 @@ async def anime_search(
             AnimeWatch,
             AnimeWatch.user_id == request_user.id if request_user else None,
         ),
+        selectinload(Anime.genres), 
+        selectinload(Anime.studios)
     ]
 
     query = select(Anime).filter(Anime.deleted == False)  # noqa: E712
+
+    if filter_ids:
+        query = query.filter(Anime.content_id.in_(filter_ids))
+
     query = anime_search_filter(search, query)
 
     query = query.order_by(*build_anime_order_by(search.sort))
@@ -211,46 +218,16 @@ async def anime_search(
     return await session.scalars(query)
 
 
-async def anime_search_total(session: AsyncSession, search: AnimeSearchArgs):
-    query = select(func.count(Anime.id)).filter(
-        Anime.deleted == False,  # noqa: E712
-    )
+async def anime_search_total(
+    session: AsyncSession,
+    search: AnimeSearchArgs,
+    filter_ids: list[str],
+):
+    query = select(func.count(Anime.id)).filter(Anime.deleted == False) # noqa: E712
+
+    if filter_ids:
+        query = query.filter(Anime.content_id.in_(filter_ids))
 
     query = anime_search_filter(search, query)
 
     return await session.scalar(query)
-
-
-# I hate this function so much
-# But we need it for having watch satatuses in Meilisearch results
-async def anime_meilisearch_watch(
-    session: AsyncSession,
-    search: AnimeSearchArgs,
-    request_user: User | None,
-    meilisearch_result: dict,
-):
-    slugs = [anime["slug"] for anime in meilisearch_result["list"]]
-
-    # Load request user watch statuses here
-    load_options = [
-        joinedload(Anime.watch),
-        with_loader_criteria(
-            AnimeWatch,
-            AnimeWatch.user_id == request_user.id if request_user else None,
-        ),
-    ]
-
-    query = select(Anime).filter(Anime.slug.in_(slugs)).options(*load_options)
-
-    if len(search.sort) > 0:
-        query = query.order_by(*build_anime_order_by(search.sort))
-
-    anime_list = await session.scalars(query)
-    meilisearch_result["list"] = anime_list.unique().all()
-
-    # Results must be sorted here to ensure same order as Meilisearch results
-    meilisearch_result["list"] = sorted(
-        meilisearch_result["list"], key=lambda x: slugs.index(x.slug)
-    )
-
-    return meilisearch_result

--- a/app/manga/router.py
+++ b/app/manga/router.py
@@ -1,8 +1,11 @@
 from app.utils import paginated_response, pagination
 from sqlalchemy.ext.asyncio import AsyncSession
+from .utils import build_manga_filters_ms
 from fastapi import APIRouter, Depends
 from app.database import get_session
 from app.models import User, Manga
+from app import meilisearch
+from app import constants
 from . import service
 
 from .dependencies import (
@@ -12,7 +15,7 @@ from .dependencies import (
 )
 
 from .schemas import (
-    MangaPaginationResponse,
+    MangaCatalogPaginationResponse,
     MangaInfoResponse,
 )
 
@@ -33,7 +36,7 @@ router = APIRouter(prefix="/manga", tags=["Manga"])
 
 @router.post(
     "",
-    response_model=MangaPaginationResponse,
+    response_model=MangaCatalogPaginationResponse,
     summary="Manga catalog",
 )
 async def search_manga(
@@ -43,19 +46,31 @@ async def search_manga(
     page: int = Depends(get_page),
     size: int = Depends(get_size),
 ):
+    limit, offset = pagination(page, size)
+
+    filter_ids = []
     if search.query:
-        return await service.manga_search_query(
-            session,
-            search,
-            request_user,
-            page,
-            size,
+        meilisearch_result = await meilisearch.search(
+            constants.SEARCH_INDEX_MANGA,
+            filter=build_manga_filters_ms(search),
+            query=search.query,
+            sort=search.sort,
+            page=page,
+            size=size,
         )
 
-    limit, offset = pagination(page, size)
-    total = await service.manga_search_total(session, search)
+        filter_ids = [hit["id"] for hit in meilisearch_result["list"]]
+
+        if not filter_ids:
+            return paginated_response([], 0, page, limit) 
+
+    total = await service.manga_search_total(session, search, filter_ids)
+
+    if total == 0:
+        return paginated_response([], 0, page, limit)
+
     manga = await service.manga_search(
-        session, search, request_user, limit, offset
+        session, search, filter_ids, request_user, limit, offset
     )
 
     return paginated_response(manga.unique().all(), total, page, limit)

--- a/app/manga/schemas.py
+++ b/app/manga/schemas.py
@@ -21,6 +21,16 @@ class MangaPaginationResponse(CustomModel):
     list: list[MangaResponseWithRead]
 
 
+class MangaCatalogResponse(MangaResponseWithRead):
+    genres: list[GenreResponse]
+    magazines: list[MagazineResponse]
+
+
+class MangaCatalogPaginationResponse(CustomModel):
+    pagination: PaginationResponse
+    list: list[MangaCatalogResponse]
+
+
 class MangaInfoResponse(CustomModel):
     data_type: Literal["manga"]
     authors: list[ContentAuthorResponse]

--- a/app/manga/service.py
+++ b/app/manga/service.py
@@ -3,11 +3,9 @@ from sqlalchemy import select, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_loader_criteria
 from app.service import manga_search_filter
-from .utils import build_manga_filters_ms
 from app.schemas import MangaSearchArgs
+from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import joinedload
-from app import meilisearch
-from app import constants
 
 from app.models import (
     MangaCharacter,
@@ -47,6 +45,7 @@ async def get_manga_by_slug(session: AsyncSession, slug: str) -> Manga | None:
 async def manga_search(
     session: AsyncSession,
     search: MangaSearchArgs,
+    filter_ids: list[str],
     request_user: User | None,
     limit: int,
     offset: int,
@@ -58,9 +57,15 @@ async def manga_search(
             MangaRead,
             MangaRead.user_id == request_user.id if request_user else None,
         ),
+        selectinload(Manga.genres),
+        selectinload(Manga.magazines),
     ]
 
     query = select(Manga).filter(Manga.deleted == False)  # noqa: E712
+
+    if filter_ids:
+        query = query.filter(Manga.content_id.in_(filter_ids))
+
     query = manga_search_filter(search, query)
 
     query = query.order_by(*build_manga_order_by(search.sort))
@@ -71,10 +76,15 @@ async def manga_search(
     return await session.scalars(query)
 
 
-async def manga_search_total(session: AsyncSession, search: MangaSearchArgs):
-    query = select(func.count(Manga.id)).filter(
-        Manga.deleted == False,  # noqa: E712
-    )
+async def manga_search_total(
+    session: AsyncSession,
+    search: MangaSearchArgs,
+    filter_ids: list[str],
+):
+    query = select(func.count(Manga.id)).filter(Manga.deleted == False) # noqa: E712
+
+    if filter_ids:
+        query = query.filter(Manga.content_id.in_(filter_ids))
 
     query = manga_search_filter(search, query)
 
@@ -99,46 +109,3 @@ async def manga_characters(
         .limit(limit)
         .offset(offset)
     )
-
-
-async def manga_search_query(
-    session: AsyncSession,
-    search: MangaSearchArgs,
-    request_user: User | None,
-    page: int,
-    size: int,
-):
-    meilisearch_result = await meilisearch.search(
-        constants.SEARCH_INDEX_MANGA,
-        filter=build_manga_filters_ms(search),
-        query=search.query,
-        sort=search.sort,
-        page=page,
-        size=size,
-    )
-
-    slugs = [manga["slug"] for manga in meilisearch_result["list"]]
-
-    # Load request user read statuses here
-    load_options = [
-        joinedload(Manga.read),
-        with_loader_criteria(
-            MangaRead,
-            MangaRead.user_id == request_user.id if request_user else None,
-        ),
-    ]
-
-    query = select(Manga).filter(Manga.slug.in_(slugs)).options(*load_options)
-
-    if len(search.sort) > 0:
-        query = query.order_by(*build_manga_order_by(search.sort))
-
-    manga_list = await session.scalars(query)
-    meilisearch_result["list"] = manga_list.unique().all()
-
-    # Results must be sorted here to ensure same order as Meilisearch results
-    meilisearch_result["list"] = sorted(
-        meilisearch_result["list"], key=lambda x: slugs.index(x.slug)
-    )
-
-    return meilisearch_result

--- a/app/novel/router.py
+++ b/app/novel/router.py
@@ -1,7 +1,9 @@
 from sqlalchemy.ext.asyncio import AsyncSession
+from .utils import build_novel_filters_ms
 from fastapi import APIRouter, Depends
 from app.database import get_session
 from app.models import User, Novel
+from app import meilisearch
 from app import constants
 from . import service
 
@@ -12,7 +14,7 @@ from .dependencies import (
 )
 
 from .schemas import (
-    NovelPaginationResponse,
+    NovelCatalogPaginationResponse,
     NovelInfoResponse,
 )
 
@@ -38,7 +40,7 @@ router = APIRouter(prefix="/novel", tags=["Novel"])
 
 @router.post(
     "",
-    response_model=NovelPaginationResponse,
+    response_model=NovelCatalogPaginationResponse,
     summary="Novel catalog",
 )
 async def search_novel(
@@ -50,19 +52,31 @@ async def search_novel(
     page: int = Depends(get_page),
     size: int = Depends(get_size),
 ):
+    limit, offset = pagination(page, size)
+
+    filter_ids = []
     if search.query:
-        return await service.novel_search_query(
-            session,
-            search,
-            request_user,
-            page,
-            size,
+        meilisearch_result = await meilisearch.search(
+            constants.SEARCH_INDEX_NOVEL,
+            filter=build_novel_filters_ms(search),
+            query=search.query,
+            sort=search.sort,
+            page=page,
+            size=size,
         )
 
-    limit, offset = pagination(page, size)
-    total = await service.novel_search_total(session, search)
+        filter_ids = [hit["id"] for hit in meilisearch_result["list"]]
+
+        if not filter_ids:
+            return paginated_response([], 0, page, limit) 
+
+    total = await service.novel_search_total(session, search, filter_ids)
+
+    if total == 0:
+        return paginated_response([], 0, page, limit)
+
     novel = await service.novel_search(
-        session, search, request_user, limit, offset
+        session, search, filter_ids, request_user, limit, offset
     )
 
     return paginated_response(novel.unique().all(), total, page, limit)

--- a/app/novel/schemas.py
+++ b/app/novel/schemas.py
@@ -19,6 +19,16 @@ class NovelPaginationResponse(CustomModel):
     list: list[NovelResponseWithRead]
 
 
+class NovelCatalogResponse(NovelResponseWithRead):
+    genres: list[GenreResponse]
+    magazines: list[MagazineResponse]
+
+
+class NovelCatalogPaginationResponse(CustomModel):
+    pagination: PaginationResponse
+    list: list[NovelCatalogResponse]
+
+
 class NovelInfoResponse(CustomModel):
     data_type: Literal["novel"]
     authors: list[ContentAuthorResponse]

--- a/app/novel/service.py
+++ b/app/novel/service.py
@@ -3,11 +3,9 @@ from sqlalchemy import select, func, ScalarResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import with_loader_criteria
 from app.service import novel_search_filter
-from .utils import build_novel_filters_ms
 from app.schemas import NovelSearchArgs
+from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import joinedload
-from app import meilisearch
-from app import constants
 
 
 from app.models import (
@@ -48,6 +46,7 @@ async def get_novel_by_slug(session: AsyncSession, slug: str) -> Novel | None:
 async def novel_search(
     session: AsyncSession,
     search: NovelSearchArgs,
+    filter_ids: list[str],
     request_user: User | None,
     limit: int,
     offset: int,
@@ -59,9 +58,15 @@ async def novel_search(
             NovelRead,
             NovelRead.user_id == request_user.id if request_user else None,
         ),
+        selectinload(Novel.genres),
+        selectinload(Novel.magazines),
     ]
 
     query = select(Novel).filter(Novel.deleted == False)  # noqa: E712
+
+    if filter_ids:
+        query = query.filter(Novel.content_id.in_(filter_ids))
+
     query = novel_search_filter(search, query)
 
     query = query.order_by(*build_novel_order_by(search.sort))
@@ -72,10 +77,15 @@ async def novel_search(
     return await session.scalars(query)
 
 
-async def novel_search_total(session: AsyncSession, search: NovelSearchArgs):
-    query = select(func.count(Novel.id)).filter(
-        Novel.deleted == False,  # noqa: E712
-    )
+async def novel_search_total(
+    session: AsyncSession,
+    search: NovelSearchArgs,
+    filter_ids: list[str],
+):
+    query = select(func.count(Novel.id)).filter(Novel.deleted == False) # noqa: E712
+
+    if filter_ids:
+        query = query.filter(Novel.content_id.in_(filter_ids))
 
     query = novel_search_filter(search, query)
 
@@ -100,46 +110,3 @@ async def novel_characters(
         .limit(limit)
         .offset(offset)
     )
-
-
-async def novel_search_query(
-    session: AsyncSession,
-    search: NovelSearchArgs,
-    request_user: User | None,
-    page: int,
-    size: int,
-):
-    meilisearch_result = await meilisearch.search(
-        constants.SEARCH_INDEX_NOVEL,
-        filter=build_novel_filters_ms(search),
-        query=search.query,
-        sort=search.sort,
-        page=page,
-        size=size,
-    )
-
-    slugs = [novel["slug"] for novel in meilisearch_result["list"]]
-
-    # Load request user read statuses here
-    load_options = [
-        joinedload(Novel.read),
-        with_loader_criteria(
-            NovelRead,
-            NovelRead.user_id == request_user.id if request_user else None,
-        ),
-    ]
-
-    query = select(Novel).filter(Novel.slug.in_(slugs)).options(*load_options)
-
-    if len(search.sort) > 0:
-        query = query.order_by(*build_novel_order_by(search.sort))
-
-    novel_list = await session.scalars(query)
-    meilisearch_result["list"] = novel_list.unique().all()
-
-    # Results must be sorted here to ensure same order as Meilisearch results
-    meilisearch_result["list"] = sorted(
-        meilisearch_result["list"], key=lambda x: slugs.index(x.slug)
-    )
-
-    return meilisearch_result

--- a/app/schedule/schemas.py
+++ b/app/schedule/schemas.py
@@ -5,7 +5,7 @@ from app.schemas import (
     AnimeResponseWithWatch,
     AnimeAgeRatingEnum,
     PaginationResponse,
-    AnimeStatusEnum,
+    ContentStatusEnum,
     CustomModel,
     SeasonEnum,
 )
@@ -15,7 +15,7 @@ from app.schemas import (
 class AnimeScheduleArgs(CustomModel):
     airing_season: list[SeasonEnum | int] | None = None
     rating: list[AnimeAgeRatingEnum] = []
-    status: list[AnimeStatusEnum] = []
+    status: list[ContentStatusEnum] = []
     only_watch: bool = False
 
     @field_validator("airing_season")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -58,12 +58,6 @@ class CompanyTypeEnum(str, Enum):
     studio = constants.COMPANY_ANIME_STUDIO
 
 
-class AnimeStatusEnum(str, Enum):
-    announced = constants.RELEASE_STATUS_ANNOUNCED
-    finished = constants.RELEASE_STATUS_FINISHED
-    ongoing = constants.RELEASE_STATUS_ONGOING
-
-
 class ContentStatusEnum(str, Enum):
     discontinued = constants.RELEASE_STATUS_DISCONTINUED
     announced = constants.RELEASE_STATUS_ANNOUNCED
@@ -322,7 +316,7 @@ class AnimeSearchArgsBase(CustomModel, YearsSeasonsMixin):
 
     media_type: list[AnimeMediaEnum] = []
     rating: list[AnimeAgeRatingEnum] = []
-    status: list[AnimeStatusEnum] = []
+    status: list[ContentStatusEnum] = []
     source: list[SourceEnum] = []
     season: list[SeasonEnum] = []
 

--- a/app/sync/search/anime.py
+++ b/app/sync/search/anime.py
@@ -57,6 +57,7 @@ async def update_anime_settings(index):
                 "score",
                 "slug",
                 "year",
+                "id",
             ],
             sortable_attributes=[
                 "native_scored_by",

--- a/app/sync/search/manga.py
+++ b/app/sync/search/manga.py
@@ -34,6 +34,7 @@ async def update_manga_settings(index):
             ],
             displayed_attributes=[
                 "slug",
+                "id",
             ],
             sortable_attributes=[
                 "native_scored_by",

--- a/app/sync/search/novel.py
+++ b/app/sync/search/novel.py
@@ -34,6 +34,7 @@ async def update_novel_settings(index):
             ],
             displayed_attributes=[
                 "slug",
+                "id",
             ],
             sortable_attributes=[
                 "native_scored_by",

--- a/app/user/service.py
+++ b/app/user/service.py
@@ -31,7 +31,6 @@ async def users_meilisearch(
     usernames = [user["username"] for user in meilisearch_result["list"]]
 
     # NOTE: we may need to preserve results order from Meilisearch here
-    # For reference see anime_meilisearch_watch function
 
     return await session.scalars(
         select(User)

--- a/tests/anime/test_anime_list.py
+++ b/tests/anime/test_anime_list.py
@@ -26,6 +26,37 @@ async def test_anime_list(client, aggregator_anime, aggregator_anime_info):
     )
 
 
+async def test_anime_list_genres_and_studios(
+    client,
+    aggregator_genres,
+    aggregator_companies,
+    aggregator_anime,
+    aggregator_anime_info,
+):
+    # Catalog entries should expose genres and studios
+    response = await request_anime_search(client)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    anime = response.json()["list"][0]
+    assert anime["slug"] == "fullmetal-alchemist-brotherhood-fc524a"
+
+    assert sorted(genre["slug"] for genre in anime["genres"]) == [
+        "action",
+        "adventure",
+        "drama",
+        "fantasy",
+        "shounen",
+    ]
+
+    assert anime["genres"][0]["name_en"] is not None
+    assert anime["genres"][0]["type"] == "genre"
+
+    # Only studios must be here, producers are a separate company type
+    assert [studio["slug"] for studio in anime["studios"]] == ["bones-b0b61b"]
+    assert anime["studios"][0]["name"] == "Bones"
+
+
 async def test_anime_no_meilisearch(client):
     # When Meilisearch is down search should throw query down error
     response = await request_anime_search(client, {"query": "test"})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -327,6 +327,13 @@ async def aggregator_companies(test_session):
 
 
 @pytest.fixture
+async def aggregator_magazines(test_session):
+    data = await helpers.load_json("tests/data/magazines.json")
+
+    await aggregator.save_magazines(test_session, data["list"])
+
+
+@pytest.fixture
 async def aggregator_anime(test_session):
     data = await helpers.load_json("tests/data/anime.json")
 
@@ -402,6 +409,7 @@ async def aggregator_manga_info(test_session):
             select(Manga)
             .filter(Manga.content_id == slug)
             .options(selectinload(Manga.genres))
+            .options(selectinload(Manga.magazines))
         ):
             data = await helpers.load_json(
                 f"tests/data/manga_info/{manga_list[slug]}"
@@ -426,6 +434,7 @@ async def aggregator_novel_info(test_session):
             select(Novel)
             .filter(Novel.content_id == slug)
             .options(selectinload(Novel.genres))
+            .options(selectinload(Novel.magazines))
         ):
             data = await helpers.load_json(
                 f"tests/data/novel_info/{novel_list[slug]}"

--- a/tests/data/magazines.json
+++ b/tests/data/magazines.json
@@ -1,0 +1,19 @@
+{
+    "list": [
+        {
+            "content_id": "4f9e5b4a-1c2d-4e8f-9a3b-6c7d8e9f0a1b",
+            "name": "Young Animal",
+            "mal_id": 2
+        },
+        {
+            "content_id": "b2c3d4e5-6f7a-4b8c-9d0e-1f2a3b4c5d6e",
+            "name": "Shounen Gangan",
+            "mal_id": 13
+        },
+        {
+            "content_id": "c3d4e5f6-7a8b-4c9d-8e0f-2a3b4c5d6e7f",
+            "name": "Comica",
+            "mal_id": 1515
+        }
+    ]
+}

--- a/tests/manga/test_manga_list.py
+++ b/tests/manga/test_manga_list.py
@@ -22,3 +22,41 @@ async def test_manga_list(
 
     # Check last manga slug
     assert response.json()["list"][3]["slug"] == "the-horizon-f9ebc0"
+
+
+async def test_manga_list_genres_and_magazines(
+    client,
+    aggregator_genres,
+    aggregator_magazines,
+    aggregator_manga,
+    aggregator_manga_info,
+):
+    # Catalog entries should expose genres and magazines
+    response = await request_manga_search(client)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    manga = response.json()["list"][0]
+    assert manga["slug"] == "berserk-fb9fbd"
+
+    genre_slugs = sorted(genre["slug"] for genre in manga["genres"])
+    assert genre_slugs == [
+        "action",
+        "adventure",
+        "award-winning",
+        "drama",
+        "fantasy",
+        "gore",
+        "horror",
+        "military",
+        "mythology",
+        "psychological",
+        "supernatural",
+    ]
+
+    assert manga["genres"][0]["name_en"] is not None
+
+    assert [magazine["slug"] for magazine in manga["magazines"]] == [
+        "young-animal-4f9e5b"
+    ]
+    assert manga["magazines"][0]["name_en"] == "Young Animal"

--- a/tests/novel/test_novel_list.py
+++ b/tests/novel/test_novel_list.py
@@ -25,3 +25,33 @@ async def test_novel_list(
         response.json()["list"][1]["slug"]
         == "kono-subarashii-sekai-ni-shukufuku-wo-cc5525"
     )
+
+
+async def test_novel_list_genres_and_magazines(
+    client,
+    aggregator_genres,
+    aggregator_magazines,
+    aggregator_novel,
+    aggregator_novel_info,
+):
+    # Catalog entries should expose genres and magazines
+    response = await request_novel_search(client)
+
+    assert response.status_code == status.HTTP_200_OK
+
+    novel = response.json()["list"][0]
+    assert novel["slug"] == "tian-guan-cifu-7bb159"
+
+    assert sorted(genre["slug"] for genre in novel["genres"]) == [
+        "action",
+        "adventure",
+        "boys-love",
+        "supernatural",
+    ]
+
+    assert novel["genres"][0]["name_en"] is not None
+    assert novel["genres"][0]["type"] == "genre"
+
+    # None of the novels in test data have magazines attached,
+    # but the field must still be exposed
+    assert novel["magazines"] == []


### PR DESCRIPTION
feat/catalog-improv

### features
- Added `genres` and `studios` fields to the `AnimeCatalogResponse`
- Added `genres` and `magazines` fields to the `MangaCatalogResponse`
- Added `genres` and `magazines` fields to the `NovelCatalogResponse`
- Changed order of operations for `/anime`, `/manga` and `/novel` endpoints:
    + Meilisearch is used in first step (optional, if search query is present)
    + Total count is calculated in the second step
    + Data list is fetched in the last step
    + Early return is present after each step which prevents useless database queries
- Removed hated functions 😉

### fixes
- Removed `AnimeStatusEnum` in favor of `ContentStatusEnum` (fixes filtering by the `discontinued` and `paused` statuses)

### tests
- Added test for anime with genres and studios in the response
- Added test for manga with genres and magazines in the response
- Added test for novel with genres and magazines in the response
- Added mock data for magazines

**Note: After merging, Meilisearch synchronization must be re-run to expose the `id` attribute. Without it, this code will fail at:**

```python
    filter_ids = [hit["id"] for hit in meilisearch_result["list"]]
```

Required for: [Перемикач між постерами і плитками в каталозі аніме](https://trello.com/c/AhxuZCGF)