### PR TITLE
(feat): Synopsis in catalog

### DIFF
--- a/app/anime/schemas.py
+++ b/app/anime/schemas.py
@@ -64,6 +64,8 @@ class AnimeSearchArgs(QuerySearchArgs, AnimeSearchArgsBase):
 class AnimeCatalogResponse(AnimeResponseWithWatch):
     genres: list[GenreResponse]
     studios: list[CompanyResponse]
+    synopsis_en: str | None
+    synopsis_ua: str | None
 
 
 class AnimeCatalogPaginationResponse(CustomModel):

--- a/app/manga/schemas.py
+++ b/app/manga/schemas.py
@@ -24,6 +24,8 @@ class MangaPaginationResponse(CustomModel):
 class MangaCatalogResponse(MangaResponseWithRead):
     genres: list[GenreResponse]
     magazines: list[MagazineResponse]
+    synopsis_en: str | None
+    synopsis_ua: str | None
 
 
 class MangaCatalogPaginationResponse(CustomModel):

--- a/app/novel/schemas.py
+++ b/app/novel/schemas.py
@@ -22,6 +22,8 @@ class NovelPaginationResponse(CustomModel):
 class NovelCatalogResponse(NovelResponseWithRead):
     genres: list[GenreResponse]
     magazines: list[MagazineResponse]
+    synopsis_en: str | None
+    synopsis_ua: str | None
 
 
 class NovelCatalogPaginationResponse(CustomModel):

--- a/tests/anime/test_anime_list.py
+++ b/tests/anime/test_anime_list.py
@@ -26,14 +26,14 @@ async def test_anime_list(client, aggregator_anime, aggregator_anime_info):
     )
 
 
-async def test_anime_list_genres_and_studios(
+async def test_anime_list_extra_fields(
     client,
     aggregator_genres,
     aggregator_companies,
     aggregator_anime,
     aggregator_anime_info,
 ):
-    # Catalog entries should expose genres and studios
+    # Catalog entries should expose genres, studios and synopsis fields
     response = await request_anime_search(client)
 
     assert response.status_code == status.HTTP_200_OK
@@ -55,6 +55,11 @@ async def test_anime_list_genres_and_studios(
     # Only studios must be here, producers are a separate company type
     assert [studio["slug"] for studio in anime["studios"]] == ["bones-b0b61b"]
     assert anime["studios"][0]["name"] == "Bones"
+
+    # Both synopsis fields must be present in the catalog response
+    assert "synopsis_en" in anime
+    assert "synopsis_ua" in anime
+    assert anime["synopsis_en"] is not None
 
 
 async def test_anime_no_meilisearch(client):

--- a/tests/manga/test_manga_list.py
+++ b/tests/manga/test_manga_list.py
@@ -24,14 +24,14 @@ async def test_manga_list(
     assert response.json()["list"][3]["slug"] == "the-horizon-f9ebc0"
 
 
-async def test_manga_list_genres_and_magazines(
+async def test_manga_list_extra_fields(
     client,
     aggregator_genres,
     aggregator_magazines,
     aggregator_manga,
     aggregator_manga_info,
 ):
-    # Catalog entries should expose genres and magazines
+    # Catalog entries should expose genres, magazines and synopsis fields
     response = await request_manga_search(client)
 
     assert response.status_code == status.HTTP_200_OK
@@ -60,3 +60,8 @@ async def test_manga_list_genres_and_magazines(
         "young-animal-4f9e5b"
     ]
     assert manga["magazines"][0]["name_en"] == "Young Animal"
+
+    # Both synopsis fields must be present in the catalog response
+    assert "synopsis_en" in manga
+    assert "synopsis_ua" in manga
+    assert manga["synopsis_en"] is not None

--- a/tests/novel/test_novel_list.py
+++ b/tests/novel/test_novel_list.py
@@ -27,14 +27,14 @@ async def test_novel_list(
     )
 
 
-async def test_novel_list_genres_and_magazines(
+async def test_novel_list_extra_fields(
     client,
     aggregator_genres,
     aggregator_magazines,
     aggregator_novel,
     aggregator_novel_info,
 ):
-    # Catalog entries should expose genres and magazines
+    # Catalog entries should expose genres, magazines and synopsis fields
     response = await request_novel_search(client)
 
     assert response.status_code == status.HTTP_200_OK
@@ -55,3 +55,8 @@ async def test_novel_list_genres_and_magazines(
     # None of the novels in test data have magazines attached,
     # but the field must still be exposed
     assert novel["magazines"] == []
+
+    # Both synopsis fields must be present in the catalog response
+    assert "synopsis_en" in novel
+    assert "synopsis_ua" in novel
+    assert novel["synopsis_en"] is not None


### PR DESCRIPTION
feat/synopsis-in-catalog

### features
- Added `synopsis_en` and `synopsis_ua` field to the response of the `search_anime`, `search_manga` and `search_novel` APIs

### tests
- Updated tests for  `search_anime`, `search_manga` and `search_novel` APIs